### PR TITLE
More typos revealed by fixed Diagnostics (incorrect quantified vars).

### DIFF
--- a/UXExperimentalTerms.kif
+++ b/UXExperimentalTerms.kif
@@ -1341,7 +1341,7 @@ buy ?ITEM, but did not.")
     (and
       (instance ?USER Agent)
       (instance ?SITE WebSite)
-      (forall (?FORUMLA)
+      (forall (?FORMULA)
         (=>
           (and
             (member ?FORMULA ?PROFILE)
@@ -1367,7 +1367,7 @@ about that visitor by someone who &%possesses that website. These facts are &%Fo
 to the user. These formulas are part of the user's &%VistorProfile.")
 
 (=>
-  (visitorParameter ?VISITOR ?FORUMLA ?SITE)
+  (visitorParameter ?VISITOR ?FORMULA ?SITE)
   (webVisitor ?VISITOR ?SITE))
 
 (=>
@@ -2124,10 +2124,10 @@ This &%proccess signifies that the &%Object which is the &%patient of the &%Watc
 
 (=>
   (instance ?PURCHASE TransactionCollection)
-  (exists (?SUBPROCCESS1 ?SUBPROCCESS2)
+  (exists (?SUBPROCESS1 ?SUBPROCESS2)
     (and
       (instance ?SUBPROCESS1 Buying)
-      (subProcess ?SUBPROCESS ?PURCHASE)
+      (subProcess ?SUBPROCESS1 ?PURCHASE)
       (instance ?SUBPROCESS2 Buying)
       (subProcess ?SUBPROCESS2 ?PURCHASE)
       (not
@@ -2516,7 +2516,7 @@ description of the &%patient of the listing.")
         (represents ?QUERY ?SEARCHATTEMPT)
         (patient ?BM ?QUERY)
         (instance ?AGENT Agent)
-        (patient ?SEARCHATTEMPT ?OBJ)
+        (patient ?SEARCHATTEMPT ?OBJECT)
         (agent ?SEARCHATTEMPT ?AGENT)))))
 
 ;; JW: Is this a process, a procedure, or a ComputerProgram?
@@ -2558,8 +2558,8 @@ description of the &%patient of the listing.")
   (instance ?SA SearchAttempt)
   (exists (?QUERY)
     (and
-      (instance ?SEARCHQUERY SearchQuery)
-      (represents ?SEARCHQUERY ?SEARCHATTEMPT))))
+      (instance ?QUERY SearchQuery)
+      (represents ?QUERY ?SA))))
 
 
 ;; SearchEngine


### PR DESCRIPTION
Now that Diagnostics work, I can see these.  Still one left.

I noticed an issue, though: there are 2 senses of 'listedOn'; FinancialOntology (listing of a stock on a market); and UXExperimentalTerms (advertisement on a web page)....