### PR TITLE
Fix reversed arguments in format EnglishLanguage geographicSubregion.

### DIFF
--- a/Economy.kif
+++ b/Economy.kif
@@ -2889,13 +2889,13 @@ is the &%UnitOfMeasure ?UNIT.")
 (currencyType Canada CanadianDollar)
 
 (instance FrenchFranc UnitOfCurrency)
-(currencyType France EuroDollar)
+(currencyType France FrenchFranc)
 
 (instance GermanMark UnitOfCurrency)
-(currencyType Germany EuroDollar)
+(currencyType Germany GermanMark)
 
 (instance ItalianLire UnitOfCurrency)
-(currencyType Italy EuroDollar)
+(currencyType Italy ItalianLire)
 
 (instance JapaneseYen UnitOfCurrency)
 (currencyType Japan JapaneseYen)
@@ -2965,7 +2965,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance AustrianSchilling UnitOfCurrency)
 
-(currencyType Austria EuroDollar)
+(currencyType Austria AustrianSchilling)
 
 (instance AzerbaijaniManat UnitOfCurrency)
 
@@ -2993,7 +2993,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance BelgianFranc UnitOfCurrency)
 
-(currencyType Belgium EuroDollar)
+(currencyType Belgium BelgianFranc)
 
 (instance BelizeDollar UnitOfCurrency)
 
@@ -3089,7 +3089,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance CypriotPound UnitOfCurrency)
 
-(currencyType Cyprus EuroDollar)
+(currencyType Cyprus CypriotPound)
 
 (instance CzechKoruna UnitOfCurrency)
 
@@ -3097,7 +3097,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance DanishKrone UnitOfCurrency)
 
-(currencyType Netherlands EuroDollar)
+(currencyType Netherlands DanishKrone)
 
 (instance DjiboutiFranc UnitOfCurrency)
 
@@ -3129,7 +3129,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance EstonianKroon UnitOfCurrency)
 
-(currencyType Estonia EuroDollar)
+(currencyType Estonia EstonianKroon)
 
 (instance EthiopianBirr UnitOfCurrency)
 
@@ -3141,7 +3141,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance FinnishMarkka UnitOfCurrency)
 
-(currencyType Finland EuroDollar)
+(currencyType Finland FinnishMarkka)
 
 (instance GabonFranc UnitOfCurrency)
 
@@ -3161,7 +3161,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance GreekDrachma UnitOfCurrency)
 
-(currencyType Greece EuroDollar)
+(currencyType Greece GreekDrachma)
 
 (instance GrenadaDollar UnitOfCurrency)
 
@@ -3221,7 +3221,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance IrishPound UnitOfCurrency)
 
-(currencyType Ireland EuroDollar)
+(currencyType Ireland IrishPound)
 
 (instance IsraeliShekel UnitOfCurrency)
 
@@ -3265,7 +3265,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance LatvianLats UnitOfCurrency)
 
-(currencyType Latvia EuroDollar)
+(currencyType Latvia LatvianLats)
 
 (instance LebanesePound UnitOfCurrency)
 
@@ -3285,11 +3285,11 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance LithuanianLitas UnitOfCurrency)
 
-(currencyType Lithuania EuroDollar)
+(currencyType Lithuania LithuanianLitas)
 
 (instance LuxembourgFranc UnitOfCurrency)
 
-(currencyType Luxembourg EuroDollar)
+(currencyType Luxembourg LuxembourgFranc)
 
 (instance MacaoPataca UnitOfCurrency)
 
@@ -3313,7 +3313,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance MalteseLira UnitOfCurrency)
 
-(currencyType Malta EuroDollar)
+(currencyType Malta MalteseLira)
 
 (instance MauritanianOuguiya UnitOfCurrency)
 
@@ -3409,7 +3409,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance PortugueseEscudo UnitOfCurrency)
 
-(currencyType Portugal EuroDollar)
+(currencyType Portugal PortugueseEscudo)
 
 (instance QatariRiyal UnitOfCurrency)
 
@@ -3453,9 +3453,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance SlovakianKoruna UnitOfCurrency)
 
-(currencyType Slovakia EuroDollar)
-
-(currencyType Slovenia EuroDollar)
+(currencyType Slovakia SlovakianKoruna)
 
 (instance SomalianShilling UnitOfCurrency)
 
@@ -3471,7 +3469,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance SpanishPeseta UnitOfCurrency)
 
-(currencyType Spain EuroDollar)
+(currencyType Spain SpanishPeseta)
 
 (instance SriLankanRupee UnitOfCurrency)
 

--- a/Economy.kif
+++ b/Economy.kif
@@ -2889,13 +2889,13 @@ is the &%UnitOfMeasure ?UNIT.")
 (currencyType Canada CanadianDollar)
 
 (instance FrenchFranc UnitOfCurrency)
-(currencyType France FrenchFranc)
+(currencyType France EuroDollar)
 
 (instance GermanMark UnitOfCurrency)
-(currencyType Germany GermanMark)
+(currencyType Germany EuroDollar)
 
 (instance ItalianLire UnitOfCurrency)
-(currencyType Italy ItalianLire)
+(currencyType Italy EuroDollar)
 
 (instance JapaneseYen UnitOfCurrency)
 (currencyType Japan JapaneseYen)
@@ -2965,7 +2965,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance AustrianSchilling UnitOfCurrency)
 
-(currencyType Austria AustrianSchilling)
+(currencyType Austria EuroDollar)
 
 (instance AzerbaijaniManat UnitOfCurrency)
 
@@ -2993,7 +2993,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance BelgianFranc UnitOfCurrency)
 
-(currencyType Belgium BelgianFranc)
+(currencyType Belgium EuroDollar)
 
 (instance BelizeDollar UnitOfCurrency)
 
@@ -3089,7 +3089,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance CypriotPound UnitOfCurrency)
 
-(currencyType Cyprus CypriotPound)
+(currencyType Cyprus EuroDollar)
 
 (instance CzechKoruna UnitOfCurrency)
 
@@ -3097,7 +3097,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance DanishKrone UnitOfCurrency)
 
-(currencyType Netherlands DanishKrone)
+(currencyType Netherlands EuroDollar)
 
 (instance DjiboutiFranc UnitOfCurrency)
 
@@ -3129,7 +3129,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance EstonianKroon UnitOfCurrency)
 
-(currencyType Estonia EstonianKroon)
+(currencyType Estonia EuroDollar)
 
 (instance EthiopianBirr UnitOfCurrency)
 
@@ -3141,7 +3141,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance FinnishMarkka UnitOfCurrency)
 
-(currencyType Finland FinnishMarkka)
+(currencyType Finland EuroDollar)
 
 (instance GabonFranc UnitOfCurrency)
 
@@ -3161,7 +3161,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance GreekDrachma UnitOfCurrency)
 
-(currencyType Greece GreekDrachma)
+(currencyType Greece EuroDollar)
 
 (instance GrenadaDollar UnitOfCurrency)
 
@@ -3221,7 +3221,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance IrishPound UnitOfCurrency)
 
-(currencyType Ireland IrishPound)
+(currencyType Ireland EuroDollar)
 
 (instance IsraeliShekel UnitOfCurrency)
 
@@ -3265,7 +3265,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance LatvianLats UnitOfCurrency)
 
-(currencyType Latvia LatvianLats)
+(currencyType Latvia EuroDollar)
 
 (instance LebanesePound UnitOfCurrency)
 
@@ -3285,11 +3285,11 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance LithuanianLitas UnitOfCurrency)
 
-(currencyType Lithuania LithuanianLitas)
+(currencyType Lithuania EuroDollar)
 
 (instance LuxembourgFranc UnitOfCurrency)
 
-(currencyType Luxembourg LuxembourgFranc)
+(currencyType Luxembourg EuroDollar)
 
 (instance MacaoPataca UnitOfCurrency)
 
@@ -3313,7 +3313,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance MalteseLira UnitOfCurrency)
 
-(currencyType Malta MalteseLira)
+(currencyType Malta EuroDollar)
 
 (instance MauritanianOuguiya UnitOfCurrency)
 
@@ -3409,7 +3409,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance PortugueseEscudo UnitOfCurrency)
 
-(currencyType Portugal PortugueseEscudo)
+(currencyType Portugal EuroDollar)
 
 (instance QatariRiyal UnitOfCurrency)
 
@@ -3453,7 +3453,9 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance SlovakianKoruna UnitOfCurrency)
 
-(currencyType Slovakia SlovakianKoruna)
+(currencyType Slovakia EuroDollar)
+
+(currencyType Slovenia EuroDollar)
 
 (instance SomalianShilling UnitOfCurrency)
 
@@ -3469,7 +3471,7 @@ is the &%UnitOfMeasure ?UNIT.")
 
 (instance SpanishPeseta UnitOfCurrency)
 
-(currencyType Spain SpanishPeseta)
+(currencyType Spain EuroDollar)
 
 (instance SriLankanRupee UnitOfCurrency)
 

--- a/domainEnglishFormat.kif
+++ b/domainEnglishFormat.kif
@@ -278,7 +278,7 @@
 (format EnglishLanguage friend "%2 is %n a &%friend of %1")
 (format EnglishLanguage geneticSubstrateOfVirus "%2 is %n a &%genetic substrate of virus of %1")
 (format EnglishLanguage GeographicCenterFn "the &%geographic center of %1")
-(format EnglishLanguage geographicSubregion "%2 is %n a &%geographic subregion of %1")
+(format EnglishLanguage geographicSubregion "%1 is %n a &%geographic subregion of %2")
 (format EnglishLanguage geometricDistance "%1 %n{doesn't} &%geometric distance %2 for %3")
 (format EnglishLanguage geometricPart "%2 is %n a &%geometric part of %1")
 (format EnglishLanguage givenName "%1 is %n a &%given&nbsp;name of %2")


### PR DESCRIPTION
For example, (geographicSubregion BarcelonaSpain Spain) says "Spain is a geographic subregion of barcelona spain". It should be the reverse.