### PR TITLE
Sports.kif: Change BaseballStrike to subclass BaseballManeuver, not instance.

### DIFF
--- a/Sports.kif
+++ b/Sports.kif
@@ -620,7 +620,7 @@ a &%BaseballWalk nor a &%BaseballHit.")
 (instance BaseballStrikeAttribute SportsAttribute)
 (documentation BaseballStrike EnglishLanguage "A baseball pitch that is in the strike zone 
 and that is not hit by the batter.")
-(instance BaseballStrike BaseballManeuver)
+(subclass BaseballStrike BaseballManeuver)
 (disjoint BaseballStrike BaseballHit)
 
 (subclass BaseballTeam SportsTeam)


### PR DESCRIPTION
BaseballStrike should not be an instance of BaseballManeuver (and Process) but a subclass, especially since we have

    (disjoint BaseballStrike BaseballHit)

and

    (subclass BaseballHit BaseballManeuver)