### PR TITLE
FinancialOntology.kif: Change ExerciseAnOption to subclass FinancialTransaction, not instance.

### DIFF
--- a/FinancialOntology.kif
+++ b/FinancialOntology.kif
@@ -2664,7 +2664,7 @@ sell its stock, at a specified price, by a specific date.")
   (underlier ?OPTION ?FI)
   (property ?OPTION Option))
 
-(instance ExerciseAnOption FinancialTransaction)
+(subclass ExerciseAnOption FinancialTransaction)
 (documentation ExerciseAnOption EnglishLanguage "An activity when the owner of the the &%Option 
 contract invokes his rights.  In the case of a call, the option owner buys the 
 underlying stock. In the case of a put, the option owner sells the underlying stock.") 


### PR DESCRIPTION
ExerciseAnOption should not be an instance of FinancialTransaction but a subclass. (This is the last example I found in SUMO of erroneous instances of Process.)