### PR TITLE
Move conventionalShortName, etc. to Mid-level-ontology.kif

### DIFF
--- a/Government.kif
+++ b/Government.kif
@@ -55,38 +55,6 @@
 
 ;;  A. Country name
 
-(instance conventionalLongName BinaryPredicate)
-
-(documentation conventionalLongName EnglishLanguage "(&%conventionalLongName ?NAME ?THING) 
-means that the string ?NAME is the long form of the name conventionally 
-used for ?THING.") 
-
-(domain conventionalLongName 1 SymbolicString)
-(domain conventionalLongName 2 Entity)
-(termFormat EnglishLanguage conventionalLongName "official name" )
-(subrelation conventionalLongName names)
-
-(instance conventionalShortName BinaryPredicate)
-
-(documentation conventionalShortName EnglishLanguage "(&%conventionalShortName ?NAME 
-?THING) means that the string ?NAME is the short form of the name 
-conventionally used for ?THING.  For a more specialized subset of short 
-names, see &%abbreviation.") 
-
-(domain conventionalShortName 1 SymbolicString)
-(domain conventionalShortName 2 Entity)
-(subrelation conventionalShortName names)
-
-(instance abbreviation BinaryPredicate)
-(domain abbreviation 1 SymbolicString)
-(domain abbreviation 2 Entity)
-(subrelation abbreviation conventionalShortName)
-
-(documentation abbreviation EnglishLanguage "(&%abbreviation ?STRING ?THING) means that 
-?STRING is an abbreviation used to refer to ?THING.  Abbreviations include 
-acronyms and other abbreviated forms.") 
-
-(termFormat EnglishLanguage conventionalShortName "acronym")
 
 ;; CIA World Fact Book classifications into 
 ;; IndependentState and DependencyOrSpecialSovereigntyArea:

--- a/Mid-level-ontology.kif
+++ b/Mid-level-ontology.kif
@@ -24340,6 +24340,41 @@ principles or a plan or course of action adopted by that organization.")
       (agent ?CREATE ?AGENT)
       (result ?CREATE ?POLICY))))      
 
+;; Abbreviations and conventional names.
+
+(instance conventionalLongName BinaryPredicate)
+
+(documentation conventionalLongName EnglishLanguage "(&%conventionalLongName ?NAME ?THING)
+means that the string ?NAME is the long form of the name conventionally
+used for ?THING.")
+
+(domain conventionalLongName 1 SymbolicString)
+(domain conventionalLongName 2 Entity)
+(termFormat EnglishLanguage conventionalLongName "official name" )
+(subrelation conventionalLongName names)
+
+(instance conventionalShortName BinaryPredicate)
+
+(documentation conventionalShortName EnglishLanguage "(&%conventionalShortName ?NAME
+?THING) means that the string ?NAME is the short form of the name
+conventionally used for ?THING.  For a more specialized subset of short
+names, see &%abbreviation.")
+
+(domain conventionalShortName 1 SymbolicString)
+(domain conventionalShortName 2 Entity)
+(subrelation conventionalShortName names)
+
+(instance abbreviation BinaryPredicate)
+(domain abbreviation 1 SymbolicString)
+(domain abbreviation 2 Entity)
+(subrelation abbreviation conventionalShortName)
+
+(documentation abbreviation EnglishLanguage "(&%abbreviation ?STRING ?THING) means that
+?STRING is an abbreviation used to refer to ?THING.  Abbreviations include
+acronyms and other abbreviated forms.")
+
+(termFormat EnglishLanguage conventionalShortName "acronym")
+
 ;; -----------------------------------------------------------------------------
 ;; Import from elements.kif
 ;; -----------------------------------------------------------------------------
@@ -24361,8 +24396,7 @@ principles or a plan or course of action adopted by that organization.")
 ; under GNU license) is being released in the public domain, in keeping
 ; with the view of the original compiler of the material.
 
-; This file depends on SUMO and the Government ontology (although only
-; for conventionalShortName).
+; This file depends on Merge.kif.
 
 ; The original information has since been augmented with data for melting
 ; and boiling points.


### PR DESCRIPTION
Move conventionalShortName, conventionalLongName and abbreviation from Government.kif to Mid-level-ontology.kif. This resolves issue #31 . In addition to conventionalShortName, it seemed appropriate to also move conventionalLongName and abbreviation, which are equally general.