### PR TITLE
Transportation.kif: Fix rule for runway length of MediumLengthRunwayAirport

### DIFF
--- a/Transportation.kif
+++ b/Transportation.kif
@@ -1347,7 +1347,7 @@ category for &%Airports whose longest runway has a length between
 (=>
 	(and
 		(instance ?AIRPORT Airport)
-		(attribute ?AIRPORT ShortRunwayAirport))
+		(attribute ?AIRPORT MediumLengthRunwayAirport))
 	(exists (?RUNWAY ?LENGTH)
 		(and
 			(instance ?RUNWAY Runway)


### PR DESCRIPTION
This is a rule for MediumLengthRunwayAirport. I suspect it was a copy/paste error from the rule for ShortRunwayAirport.
