### PR TITLE
Merge.kif: For PacificTimeZone, etc. the offset should specifically be in hours.

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -14726,7 +14726,7 @@ western part of the United States.")
 
 (=>
    (equal (RelativeTimeFn ?TIME1 PacificTimeZone) ?TIME2) 
-   (equal ?TIME2 (AdditionFn ?TIME1 8)))
+   (equal ?TIME2 (AdditionFn ?TIME1 (MeasureFn 8 HourDuration))))
 
 (instance MountainTimeZone TimeZone)
 (documentation MountainTimeZone EnglishLanguage "A &%TimeZone that covers much of the 
@@ -14734,7 +14734,7 @@ Rocky Mountain region of the United States.")
 
 (=>
    (equal (RelativeTimeFn ?TIME1 MountainTimeZone) ?TIME2) 
-   (equal ?TIME2 (AdditionFn ?TIME1 7)))
+   (equal ?TIME2 (AdditionFn ?TIME1 (MeasureFn 7 HourDuration))))
 
 (instance CentralTimeZone TimeZone)
 (documentation CentralTimeZone EnglishLanguage "A &%TimeZone that covers much of the 
@@ -14742,7 +14742,7 @@ midwestern United States.")
 
 (=>
    (equal (RelativeTimeFn ?TIME1 CentralTimeZone) ?TIME2) 
-   (equal ?TIME2 (AdditionFn ?TIME1 6)))
+   (equal ?TIME2 (AdditionFn ?TIME1 (MeasureFn 6 HourDuration))))
 
 (instance EasternTimeZone TimeZone)
 (documentation EasternTimeZone EnglishLanguage "A &%TimeZone that covers much of the 
@@ -14750,7 +14750,7 @@ eastern United States.")
 
 (=>
    (equal (RelativeTimeFn ?TIME1 EasternTimeZone) ?TIME2) 
-   (equal ?TIME2 (AdditionFn ?TIME1 5)))
+   (equal ?TIME2 (AdditionFn ?TIME1 (MeasureFn 5 HourDuration))))
 
 (instance RelativeTimeFn BinaryFunction)
 (instance RelativeTimeFn TemporalRelation)


### PR DESCRIPTION
The documentation for RelativeTimeFn gives the example " (RelativeTimeFn (MeasureFn 14 HourDuration) EasternTimeZone)" using HourDuration. But the actual statements for the relative time of time zones are ambiguous. So, need to use MeasureFn with HourDuration.