### PR TITLE
Added gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# ignore all files in the build/ directory
+tests/ 
+
+# no .tptp files
+*.tptp
+
+# no Cache.kif andd UserAssertions files
+*_Cache.kif
+*_UserAssertions.kif
+
+# specific files to ignore:
+config.xml
+
+# txt files in KB directory
+/EBatchConfig.txt
+/emptyConstituent.txt
+
+# WordNet files
+WordNetMappings/Makefile*
+WordNetMappings/*.exc
+WordNetMappings/data.*
+WordNetMappings/index.*
+WordNetMappings/cntlist*
+WordNetMappings/frames.vrb
+WordNetMappings/language.txt
+WordNetMappings/lexnames
+WordNetMappings/log.grind.3.0
+WordNetMappings/sentidx.vrb
+WordNetMappings/sents.vrb
+WordNetMappings/verb.Framestext


### PR DESCRIPTION
In order to be able to use the full possibilities of git (for example working with branches), I wanted the KBs directory to be the same as my working copy of the sumo repository. This gitignore file will make git ignore the files that are automatically generated by Sigma and that have to be added during instalation to the KBs directory so that WordNet mappings to work.

You can add the .gitignore file itself to the list and add additional files like temporary files from your editor or file manager.

What do you think of this?

If you agree to change the workflow this way, it might be a good idea to update also the setup instructions accordingly. It is not necessary to pull this right away into master, it might be a good idea to test it first.