### PR TITLE
Mid-level-ontology: Removed obsolete comment on MusicalComposition.

### DIFF
--- a/Mid-level-ontology.kif
+++ b/Mid-level-ontology.kif
@@ -10810,15 +10810,6 @@ and musical composition combined.")
 (documentation MusicalComposition EnglishLanguage "&%MusicalComposition refers to the
 the conception of a musical arrangement not including any &%LyricalContent.")
 (termFormat EnglishLanguage MusicalComposition "musical composition")
-(comment MusicalComposition "Currently, MusicalComposition is treated as text, and there 
-is no propositional content related to it.  This is dangerous, as there could be millions 
-of instances of (for instance) sheet music containing Beethoven's Fifth Symphony, and 
-only having MusicalComposition equal to an object would imply that all of this different 
-instances are different from each other.  You could also have many different arrangements 
-of the same musical composition.  As such, I propose making MusicalComposition a Proposition, 
-which refers more to the conception of the music, and SheetMusic the content bearing 
-object that contains information about a particular MusicalComposition.  (09-13-2011)" 
-"KJN")
 
 (=> 
   (and


### PR DESCRIPTION
MusicalComposition was formerly a subclass of Text. There was a very good comment on why it should instead be a subclass of Proposition. And in 2011 it was changed to a subclass of Music (which is a subclass of Proposition):

https://github.com/ontologyportal/sumo/commit/b979e179ff217a80b4ca65413e0c53631ae589a2#diff-02a35207d53d8a4a24c8e1a89addbce1

So, the comment can be removed since it still appears and causes confusion.