### PR TITLE
Change UniformResourceIdentifier to be a subclass of List .

### DIFF
--- a/QoSontology.kif
+++ b/QoSontology.kif
@@ -1652,7 +1652,7 @@ attribute of executing computer programs or collections of executing
 programs, such as CPU utilization, aka load, memory utilization, I/O, 
 overall task performance, network load and latency, etc.")
 
-(subclass UniformResourceIdentifier ContentBearingObject)
+(subclass UniformResourceIdentifier List)
 (exhaustiveDecomposition UniformResourceIdentifier UniformResourceLocator UniformResourceName) 
 (documentation UniformResourceIdentifier EnglishLanguage  "A &%UniformResourceIdentifier 
 (URI) is a compact string of characters for identifying an abstract or 


### PR DESCRIPTION
Currently UniformResourceIdentifier is in the class hierarchy under a physical CorpuscularObject. Surely a URI is not an object with a physical location any more than the RationalNumber 2/3 is. This pull request changes it to a subclass of List since it is an abstract list of characters.