### PR TITLE
Fix typo "exist" -> "exists"

### DIFF
--- a/Mid-level-ontology.kif
+++ b/Mid-level-ontology.kif
@@ -15568,7 +15568,7 @@ in a &%MotionPicture or the &%Performance of a &%DramaticPlay.")
  
 (=>
   (instance ?X DramaticDirecting)
-  (exist (?D)
+  (exists (?D)
     (and
       (instance ?D Directing)
       (subProcess ?D ?X))))


### PR DESCRIPTION
Just a silly typo.

@apease please merge at your convenience.

Thanks,
Marty
