### PR TITLE
GeochronologicTimes.kif and updated WN mappings

### DIFF
--- a/GeochronologicTimes.kif
+++ b/GeochronologicTimes.kif
@@ -13,11 +13,27 @@
 (termFormat PortugueseLanguage GeochronologicSuperEon "super éon")
 
 (subclass GeochronologicEon TimeInterval)
+(termFormat EnglishLanguage GeochronologicEon "eon")
+(termFormat PortugueseLanguage GeochronologicEon "éon")
+
 (subclass GeochronologicEra TimeInterval)
+(termFormat EnglishLanguage GeochronologicEra "era")
+(termFormat PortugueseLanguage GeochronologicEra "era")
+
 (subclass GeochronologicPeriod TimeInterval)
+(termFormat EnglishLanguage GeochronologicPeriod "period")
+(termFormat PortugueseLanguage GeochronologicPeriod "período")
+
 (subclass GeochronologicSubPeriod TimeInterval)
+(termFormat EnglishLanguage GeochronologicSubPeriod "sub period")
+
 (subclass GeochronologicEpoch TimeInterval)
+(termFormat EnglishLanguage GeochronologicEpoch "epoch")
+(termFormat PortugueseLanguage GeochronologicEpoch "época")
+
 (subclass GeochronologicAge TimeInverval)
+(termFormat EnglishLanguage GeochronologicAge "age")
+(termFormat PortugueseLanguage GeochronologicAge "idade")
 
 ;; The hierarchy is
 ;; SuperEon > Eon > Era > Period > SubPeriod > Epoch > Age
@@ -33,145 +49,225 @@
 
 (instance Phanerozoic GeochronologicEon)
 (earlier Precambrian Phanerozoic)
+(termFormat EnglishLanguage Phanerozoic "Phanerozoic")
+(termFormat PortugueseLanguage Phanerozoic "Fanerozóico")
 
 (instance Proterozoic GeochronologicEon)
 (earlier Proterozoic Phanerozoic)
 (during Proterozoic Precambrian)
+(termFormat EnglishLanguage Proterozoic "Proterozoic")
+(termFormat PortugueseLanguage Proterozoic "Proterozóico")
 
 (instance Archean GeochronologicEon)
 (earlier Archean Proterozoic)
 (during Archean Precambrian)
+(termFormat EnglishLanguage Archean "Archean")
+(termFormat PortugueseLanguage Archean "Arqueano")
 
 (instance Hadean GeochronologicEon)
 (earlier Hadean Archean)
 (during Hadean Precambrian)
+(termFormat EnglishLanguage Hadean "Hadean")
+(termFormat PortugueseLanguage Hadean "Hadeano")
 
 ;; Eras
 
 (instance Cenozoic GeochronologicEra)
 (during Cenozoic Phanerozoic)
+(termFormat EnglishLanguage Cenozoic "Cenozoic")
+(termFormat PortugueseLanguage Cenozoic "Cenozóico")
 
 (instance Mesozoic GeochronologicEra)
 (during Mesozoic Phanerozoic)
 (earlier Mesozoic Cenozoic)
+(termFormat EnglishLanguage Mesozoic "Mesozoic")
+(termFormat PortugueseLanguage Mesozoic "Mesozóico")
 
 (instance Paleozoic GeochronologicEra)
 (during Paleozoic Phanerozoic)
 (earlier Paleozoic Mesozoic)
+(termFormat EnglishLanguage Paleozoic "Paleozoic")
+(termFormat PortugueseLanguage Paleozoic "Paleozóico")
 
 (instance Neo-proterozoic GeochronologicEra)
 (during Neo-proterozoic Proterozoic)
+(termFormat EnglishLanguage Neo-proterozoic "Neo-proterozoic")
+(termFormat PortugueseLanguage Neo-proterozoic "Neoproterozóico")
 
 (instance Meso-proterozoic GeochronologicEra)
 (during Meso-proterozoic Proterozoic)
 (earlier Meso-proterozoic Neo-proterozoic)
+(termFormat EnglishLanguage Meso-proterozoic "Meso-proterozoic")
+(termFormat PortugueseLanguage Meso-proterozoic "Mesoproterozóico")
 
 (instance Paleo-proterozoic GeochronologicEra)
 (during Paleo-proterozoic Proterozoic)
 (earlier Paleo-proterozoic Meso-proterozoic)
+(termFormat EnglishLanguage Paleo-proterozoic "Paleo-proterozoic")
+(termFormat PortugueseLanguage Paleo-proterozoic "Paleoproterozóico")
 
 (instance Neo-archean GeochronologicEra)
 (during Neo-archean Archean)
+(termFormat EnglishLanguage Neo-archean "Neo-archean")
+(termFormat PortugueseLanguage Neo-archean "Neo-arqueano")
 
 (instance Meso-archean GeochronologicEra)
 (during Meso-archean Archean)
 (earlier Meso-archean Neo-archean)
+(termFormat EnglishLanguage Meso-archean "Meso-archean")
+(termFormat PortugueseLanguage Meso-archean "Meso-arqueano")
 
 (instance Paleo-archean GeochronologicEra)
 (during Paleo-archean Archean)
 (earlier Paleo-archean Meso-archean)
+(termFormat EnglishLanguage Paleo-archean "Paleo-archean")
+(termFormat PortugueseLanguage Paleo-archean "Paleo-arqueano")
 
 (instance Eo-archean GeochronologicEra)
 (during Eo-archean Archean)
 (earlier Eo-archean Paleo-archean)
+(termFormat EnglishLanguage Eo-archean "Eo-archean")
+(termFormat PortugueseLanguage Eo-archean "Eo-arqueano")
 
 ;; Periods
 
 (instance Quaternary GeochronologicPeriod)
 (during Quaternary Cenozoic)
+(termFormat EnglishLanguage Quaternary "Quaternery")
+(termFormat PortugueseLanguage Quaternery "Quaternário")
 
 (instance Neogene GeochronologicPeriod)
 (during Neogene Cenozoic)
 (earlier Neogene Quaternary)
+(termFormat EnglishLanguage Neogene "Neogene")
+(termFormat PortugueseLanguage Neogene "Neogeno")
 
 (instance Paleogene GeochronologicPeriod)
 (during Paleogene Cenozoic)
 (earlier Paleogene Neogene)
+(termFormat EnglishLanguage Paleogene "Paleogene")
+(termFormat PortugueseLanguage Paleogene "Paleogeno")
 
 (instance Cretaceous GeochronologicPeriod)
 (during Cretaceous Mesozoic)
+(termFormat EnglishLanguage Cretaceous "Cretaceous")
+(termFormat PortugueseLanguage Cretaceous "Cretácio")
 
 (instance Jurassic GeochronologicPeriod)
 (during Jurassic Mesozoic)
 (earlier Jurassic Cretaceous)
+(termFormat EnglishLanguage Jurassic "Jurassic")
+(termFormat PortugueseLanguage Jurassic "Jurássico")
 
 (instance Triassic GeochronologicPeriod)
 (during Triassic Mesozoic)
 (earlier Triassic Jurassic)
+(termFormat EnglishLanguage Triassic "Triassic")
+(termFormat PortugueseLanguage Triassic "Triássico")
 
 (instance Permian GeochronologicPeriod)
 (during Permian Paleozoic)
+(termFormat EnglishLanguage Permian "Permian")
+(termFormat PortugueseLanguage Permian "Permiano")
+
+(instance Carboniferus GeochronologicPeriod)
+(during Carboniferus Paleozoic)
+(earlier Carboniferus Permian)
+(termFormat EnglishLanguage Carboniferus "Carboniferus")
+(termFormat PortugueseLanguage Carboniferus "Carbonífero")
 
 (instance Devonian GeochronologicPeriod)
 (during Devonian Paleozoic)
+(termFormat EnglishLanguage Devonian "Devonian")
+(termFormat PortugueseLanguage Devonian "Devoniano")
 
 (instance Silurian GeochronologicPeriod)
 (during Silurian Paleozoic)
 (earlier Silurian Devonian)
+(termFormat EnglishLanguage Silurian "Silurian")
+(termFormat PortugueseLanguage Silurian "Siluriano")
 
 (instance Ordovician GeochronologicPeriod)
 (during Ordovician Paleozoic)
 (earlier Ordovician Silurian)
+(termFormat EnglishLanguage Ordovician "Ordovician")
+(termFormat PortugueseLanguage Ordovician "Ordoviciano")
 
 (instance Cambrian GeochronologicPeriod)
 (during Cambrian Paleozoic)
 (earlier Cambrian Ordovician)
+(termFormat EnglishLanguage Cambrian "Cambrian")
+(termFormat PortugueseLanguage Cambrian "Cambriano")
 
 (instance Ediacaran GeochronologicPeriod)
 (during Ediacaran Neo-proterozoic)
+(termFormat EnglishLanguage Ediacaran "Ediacaran")
+(termFormat PortugueseLanguage Ediacaran "Ediacarano")
 
 (instance Cryogenian GeochronologicPeriod)
 (during Cryogenian Neo-proterozoic)
 (earlier Cryogenian Ediacaran)
+(termFormat EnglishLanguage Cryogenian "Cryogenian")
+(termFormat PortugueseLanguage Cryogenian "Criogeniano")
 
 (instance Tonian GeochronologicPeriod)
 (during Tonian Neo-proterozoic)
 (earlier Tonian Cryogenian)
+(termFormat EnglishLanguage Tonian "Tonian")
+(termFormat PortugueseLanguage Tonian "Tonian")
 
 (instance Stenian GeochronologicPeriod)
 (during Stenian Meso-proterozoic)
+(termFormat EnglishLanguage Stenian "Stenian")
+(termFormat PortugueseLanguage Stenian "Steniano")
 
 (instance Ectasian GeochronologicPeriod)
 (during Ectasian Meso-proterozoic)
 (earlier Ectasian Stenian)
+(termFormat EnglishLanguage Ectasian "Ectasian")
+(termFormat PortugueseLanguage Ectasian "Ectasiano")
 
 (instance Calymmian GeochronologicPeriod)
 (during Calymmian Meso-proterozoic)
 (earlier Calymmian Ectasian)
+(termFormat EnglishLanguage Calymmian "Calymmian")
+(termFormat PortugueseLanguage Calymmian "Calymmian")
 
 (instance Statherian GeochronologicPeriod)
 (during Statherian Paleo-proterozoic)
+(termFormat EnglishLanguage Statherian "Statherian")
+(termFormat PortugueseLanguage Statherian "Statheriano")
 
 (instance Orosirian GeochronologicPeriod)
 (during Orosirian Paleo-proterozoic)
 (earlier Orosirian Statherian)
+(termFormat EnglishLanguage Orosirian "Orosirian")
+(termFormat PortugueseLanguage Orosirian "Orosiriano")
 
 (instance Rhyacian GeochronologicPeriod)
 (during Rhyacian Paleo-proterozoic)
 (earlier Rhyacian Orosirian)
+(termFormat EnglishLanguage Rhyacian "Rhyacian")
+(termFormat PortugueseLanguage Rhyacian "Rhyaciano")
 
 (instance Siderian GeochronologicPeriod)
 (during Siderian Paleo-proterozoic)
 (earlier Siderian Rhyacian)
+(termFormat EnglishLanguage Siderian "Siderian")
+(termFormat PortugueseLanguage Siderian "Sideriano")
 
 ;; SubPeriods
 
 (instance Pennsylvanian GeochronologicSubPeriod)
 (during Pennsylvanian Carboniferous)
+(termFormat EnglishLanguage Pennsylvanian "Pennsylvanian")
+(termFormat PortugueseLanguage Pennsylvanian "Pensilvaniano")
 
 (instance Mississippian GeochronologicSubPeriod)
 (during Mississippian Carboniferous)
 (earlier Mississippian Pennsylvanian)
+(termFormat EnglishLanguage Mississippian "Mississippian")
+(termFormat PortugueseLanguage Mississippian "Mississippiano")
 
 ;; Epochs 
 
@@ -182,65 +278,95 @@
 
 (instance Holocene GeochronologicEpoch)
 (during Holocene Quaternary)
+(termFormat EnglishLanguage Holocene "Holocene")
+(termFormat PortugueseLanguage Holocene "Holoceno")
 
 (instance Pleistocene GeochronologicEpoch)
 (during Pleistocene Quaternary)
 (earlier Pleistocene Holocene)
+(termFormat EnglishLanguage Pleistocene "Pleistocene")
+(termFormat PortugueseLanguage Pleistocene "Pleistoceno")
 
 (instance Pliocene GeochronologicEpoch)
 (during Pliocene Neogene)
+(termFormat EnglishLanguage Pliocene "Pliocene")
+(termFormat PortugueseLanguage Pliocene "Plioceno")
 
 (instance Miocene GeochronologicEpoch)
 (during Miocene Neogene)
 (earlier Miocene Pliocene)
+(termFormat EnglishLanguage Miocene "Miocene")
+(termFormat PortugueseLanguage Miocene "Mioceno")
 
 (instance Oligocene GeochronologicEpoch)
 (during Oligocene Paleogene)
+(termFormat EnglishLanguage Oligocene "Oligocene")
+(termFormat PortugueseLanguage Oligocene "Oligoceno")
 
 (instance Eocene GeochronologicEpoch)
 (during Eocene Paleogene)
 (earlier Eocene Oligocene)
+(termFormat EnglishLanguage Eocene "Eocene")
+(termFormat PortugueseLanguage Eocene "Eoceno")
 
 (instance Paleocene GeochronologicEpoch)
 (during Paleocene Paleogene)
 (earlier Paleocene Eocene)
+(termFormat EnglishLanguage Paleocene "Paleocene")
+(termFormat PortugueseLanguage Paleocene "Paleoceno")
 
 ;; Cretaceous, Jurassic and Triassic's Epochs are called
 ;; Upper, Middle and Lower. 
 
 (instance Lopingian GeochronologicEpoch)
 (during Lopingian Permian)
+(termFormat EnglishLanguage Lopingian "Lopingian")
+(termFormat PortugueseLanguage Lopingian "Lopingiano")
 
 (instance Guadalupian GeochronologicEpoch)
 (during Guadalupian Permian)
 (earlier Guadalupian Lopingian)
+(termFormat EnglishLanguage Guadalupian "Guadalupian")
+(termFormat PortugueseLanguage Guadalupian "Guadalupiano")
 
 (instance Cisuralian GeochronologicEpoch)
 (during Cisuralian Permian)
 (earlier Cisuralian Guadalupian)
+(termFormat EnglishLanguage Cisuralian "Cisuralian")
+(termFormat PortugueseLanguage Cisuralian "Cisuraliano")
 
 ;; Pennsylvanian, Mississippian and Devonian's Epochs are called
 ;; Upper, Middle and Lower.
 
 (instance Pridoli GeochronologicEpoch)
 (during Pridoli Silurian)
+(termFormat EnglishLanguage Priodoli "Priodoli")
+(termFormat PortugueseLanguage Priodoli "Priodoli")
 
 (instance Ludlow GeochronologicEpoch)
 (during Ludlow Silurian)
 (earlier Ludlow Pridoli)
+(termFormat EnglishLanguage Ludlow "Ludlow")
+(termFormat PortugueseLanguage Ludlow "Ludlow")
 
 (instance Wenlock GeochronologicEpoch)
 (during Wenlock Silurian)
 (earlier Wenlock Ludlow)
+(termFormat EnglishLanguage Wenlock "Wenlock")
+(termFormat PortugueseLanguage Wenlock "Wenlock")
 
 (instance Llandovery GeochronologicEpoch)
 (during Llandovery Silurian)
 (earlier Llandovery Wenlock)
+(termFormat EnglishLanguage Llandovery "Llandovery")
+(termFormat PortugueseLanguage Llandovery "Llandovery")
 
 ;; Ordovician's Epochs are called Upper, Middle and Lower.
 
 (instance Furongian GeochronologicEpoch)
 (during Furongian Cambrian)
+(termFormat EnglishLanguage Furongian "Furongian")
+(termFormat PortugueseLanguage Furongian "Furongiano")
 
 ;; Two of the Cambrian's Epochs are nameless. ICS calls them
 ;; Series 3 and Series 2.
@@ -248,3 +374,5 @@
 (instance Terreneuvian GeochronologicEpoch)
 (during Terreneuvian Cambrian)
 (earlier Terreneuvian Furongian)
+(termFormat EnglishLanguage Terreneuvian "Terreneuvian")
+(termFormat PortugueseLanguage Terreneuvian "Terreneuviano")


### PR DESCRIPTION
WN is missing some names of names of periods, eras etc:

- Paleogene
- Neogene
- Neo-proterozoic
- Meso-proterozoic
- Paleo-proterozoic
- Neo-archean
- Meso-archean
- Paleo-archean
- Eo-archean

On the other hand, PWN contains a deprecated name 'Tertiary'. See https://en.wikipedia.org/wiki/Tertiary:

> Tertiary is the former term for the geologic period from 65 million to 2.58 million years ago, a timespan that occurs between the superseded Secondary period and the Quaternary. The Tertiary is no longer recognized as a formal unit by the International Commission on Stratigraphy,[1][2][3][4] but the word is still widely used. The traditional span of the Tertiary has been divided between the Paleogene and Neogene periods and extends to the first stage of the Pleistocene Epoch, the Gelasian stage.

Not sure how to deal with such cases since new releases of PWN are not expected soon. We have started a possible expansion of PWN in https://github.com/own-pt/own-en, but it is a social issue how to make it relevant enough to having SUMO mapped to it. Another possible approach is to adopt CILI as the new global index for wordnets instead of PWN (http://compling.hss.ntu.edu.sg/iliomw/ili). 

@apease ideas?