### PR TITLE
Remove relation `meronym` and replace its calls with `part` or `properPart`

### DIFF
--- a/domainEnglishFormat.kif
+++ b/domainEnglishFormat.kif
@@ -6617,7 +6617,6 @@
 (termFormat EnglishLanguage MereologicalDifferenceFn "mereological difference")
 (termFormat EnglishLanguage MereologicalProductFn "mereological product")
 (termFormat EnglishLanguage MereologicalSumFn "mereological sum")
-(termFormat EnglishLanguage meronym "meronym")
 (termFormat EnglishLanguage MersinTurkey "mersin turkey")
 (termFormat EnglishLanguage Mesa "mesa")
 (termFormat EnglishLanguage Message "message")

--- a/engineering.kif
+++ b/engineering.kif
@@ -754,16 +754,16 @@ mechanism in order to change the speed or direction of transmitted motion.")
 direction of an angular motion, ideal gear train can be modeled using
 a transformer.")
 (subclass GearTrain MechanicalDevice)
-(part Gear GearTrain)
+(properPart Gear GearTrain)
 
 (documentation Gearbox EnglishLanguage "A device composed of several gear-trains used
 to change speed and torque of transmitted motion.")
 (subclass Gearbox MechanicalDevice)
-(part GearTrain Gearbox)
+(properPart GearTrain Gearbox)
 
 (documentation Shaft EnglishLanguage "A revolving rod that transmits power or motion.")
 (subclass Shaft MechanicalDevice)
-(part Shaft Motor)
+(properPart Shaft Motor)
 
 (documentation Spring EnglishLanguage "a metal device that returns to its shape or
 position when pushed or pulled or pressed")
@@ -1062,16 +1062,16 @@ or switching.")
 from the collector")
 (subclass Base Terminal)
 (lexicon Base LexNoun "base")
-(part Base BjtTransistor)
+(properPart Base BjtTransistor)
 (documentation Collector EnglishLanguage "the electrode in a transistor through which a 
 primary flow of carriers leaves the inter-electrode region")
 (subclass Collector Terminal)
 (lexicon Collector LexNoun "collector")
-(part Collector BjtTransistor)
+(properPart Collector BjtTransistor)
 (documentation Emitter EnglishLanguage "the electrode in a transistor where electrons originate")
 (subclass Emitter Terminal)
 (lexicon Emitter LexNoun "emitter")
-(part Emitter BjtTransistor)
+(properPart Emitter BjtTransistor)
 
 (documentation BjtTransistor EnglishLanguage "Bipolar transistor")
 (lexicon BjtTransistor LexNoun "BJT transistor")

--- a/engineering.kif
+++ b/engineering.kif
@@ -67,16 +67,6 @@ convenient for modeling of certain class of devices.")
 physical object, is subject to abstraction and idealization.")
 (subclass Model Abstract)
 
-(documentation meronym EnglishLanguage "A relation similar to WordNet meronymy relation.
-If class A is a meronym of class B, it means that instances of A
-typically are parts of instances of B.")
-(instance meronym AsymmetricRelation)
-(instance meronym TransitiveRelation)
-(domainSubclass meronym 1 Object)
-(domainSubclass meronym 2 Object)
-(format EnglishLanguage meronym "%1 is %n a meronym of %2")
-
-
 (documentation PhysicalDimension EnglishLanguage "A physical dimension such as
 length, mass, force etc.")
 (lexicon PhysicalDimension LexNoun "physical dimension")
@@ -764,16 +754,16 @@ mechanism in order to change the speed or direction of transmitted motion.")
 direction of an angular motion, ideal gear train can be modeled using
 a transformer.")
 (subclass GearTrain MechanicalDevice)
-(meronym Gear GearTrain)
+(part Gear GearTrain)
 
 (documentation Gearbox EnglishLanguage "A device composed of several gear-trains used
 to change speed and torque of transmitted motion.")
 (subclass Gearbox MechanicalDevice)
-(meronym GearTrain Gearbox)
+(part GearTrain Gearbox)
 
 (documentation Shaft EnglishLanguage "A revolving rod that transmits power or motion.")
 (subclass Shaft MechanicalDevice)
-(meronym Shaft Motor)
+(part Shaft Motor)
 
 (documentation Spring EnglishLanguage "a metal device that returns to its shape or
 position when pushed or pulled or pressed")
@@ -1072,16 +1062,16 @@ or switching.")
 from the collector")
 (subclass Base Terminal)
 (lexicon Base LexNoun "base")
-(meronym Base BjtTransistor)
+(part Base BjtTransistor)
 (documentation Collector EnglishLanguage "the electrode in a transistor through which a 
 primary flow of carriers leaves the inter-electrode region")
 (subclass Collector Terminal)
 (lexicon Collector LexNoun "collector")
-(meronym Collector BjtTransistor)
+(part Collector BjtTransistor)
 (documentation Emitter EnglishLanguage "the electrode in a transistor where electrons originate")
 (subclass Emitter Terminal)
 (lexicon Emitter LexNoun "emitter")
-(meronym Emitter BjtTransistor)
+(part Emitter BjtTransistor)
 
 (documentation BjtTransistor EnglishLanguage "Bipolar transistor")
 (lexicon BjtTransistor LexNoun "BJT transistor")

--- a/engineering.kif
+++ b/engineering.kif
@@ -754,16 +754,16 @@ mechanism in order to change the speed or direction of transmitted motion.")
 direction of an angular motion, ideal gear train can be modeled using
 a transformer.")
 (subclass GearTrain MechanicalDevice)
-(properPart Gear GearTrain)
+(typicalPart Gear GearTrain)
 
 (documentation Gearbox EnglishLanguage "A device composed of several gear-trains used
 to change speed and torque of transmitted motion.")
 (subclass Gearbox MechanicalDevice)
-(properPart GearTrain Gearbox)
+(typicalPart GearTrain Gearbox)
 
 (documentation Shaft EnglishLanguage "A revolving rod that transmits power or motion.")
 (subclass Shaft MechanicalDevice)
-(properPart Shaft Motor)
+(typicalPart Shaft Motor)
 
 (documentation Spring EnglishLanguage "a metal device that returns to its shape or
 position when pushed or pulled or pressed")
@@ -1062,16 +1062,16 @@ or switching.")
 from the collector")
 (subclass Base Terminal)
 (lexicon Base LexNoun "base")
-(properPart Base BjtTransistor)
+(typicalPart Base BjtTransistor)
 (documentation Collector EnglishLanguage "the electrode in a transistor through which a 
 primary flow of carriers leaves the inter-electrode region")
 (subclass Collector Terminal)
 (lexicon Collector LexNoun "collector")
-(properPart Collector BjtTransistor)
+(typicalPart Collector BjtTransistor)
 (documentation Emitter EnglishLanguage "the electrode in a transistor where electrons originate")
 (subclass Emitter Terminal)
 (lexicon Emitter LexNoun "emitter")
-(properPart Emitter BjtTransistor)
+(typicalPart Emitter BjtTransistor)
 
 (documentation BjtTransistor EnglishLanguage "Bipolar transistor")
 (lexicon BjtTransistor LexNoun "BJT transistor")


### PR DESCRIPTION
Some of the calls should probably use `properPart`. I'd say, all of them. @apease ?