### PR TITLE
solves #163

### DIFF
--- a/ComputerInput.kif
+++ b/ComputerInput.kif
@@ -129,55 +129,6 @@
       (patient ?PGUIDE ?MOVED)
       (instance ?MOVED CorpuscularObject))))
 
-; ===============
-(instance shape BinaryPredicate)
-(subrelation shape property)
-(domain shape 1 Physical)
-(domain shape 2 ShapeAttribute)
-(documentation shape EnglishLanguage "(shape ?OBJECT ?SHAPE) means that the shape of ?OBJECT is ?SHAPE.")
-
-; If a &%Physical object has a property which is an instance of &%ShapeAttribute,
-; then that object has that shape:
-
-(=>
-  (and
-    (property ?OBJ ?SHAPE)
-    (instance ?OBJ Physical)
-    (instance ?SHAPE ShapeAttribute))
-  (shape ?OBJ ?SHAPE))
-
-(instance RoundTwoDimensional ShapeAttribute)
-(documentation RoundTwoDimensional EnglishLanguage "The attribute of being round in two dimensions.")
-
-(instance Elliptical ShapeAttribute)
-(subAttribute Elliptical RoundTwoDimensional)
-(documentation Elliptical EnglishLanguage "The attribute of being elliptical or oval in two dimensions.")
-
-(=>
-  (instance ?SHAPE Oval)
-  (shape ?SHAPE Elliptical))
-
-(instance Circular ShapeAttribute)
-(subAttribute Circular RoundTwoDimensional)
-(documentation Circular EnglishLanguage "The attribute of being circular in two dimensions.")
-
-(=>
-  (instance ?SHAPE Circle)
-  (shape ?SHAPE Circular))
-
-(instance DiskShaped ShapeAttribute)
-(documentation DiskShaped EnglishLanguage "The attribute of being circular in one dimension and flat in the other.")
-(subAttribute DiskShaped Circular)
-(subAttribute DiskShaped Flat)
-
-(subclass SphericalObject Object)
-(documentation SphericalObject EnglishLanguage "An object with the attribute of being spherical.")
-
-(=>
-  (instance ?SPHERE SphericalObject)
-  (shape ?SHAPE Sphere))
-
-; =========================================================
 
 (subclass Keyboard Device)
 (documentation Keyboard EnglishLanguage "A &%Keyboard has a set of keys for typing on to transmit data corresponding to those keys or to cause physical action such as striking or plucking a string, opening a valve, or marking of the selected keys on paper or some other surface.")

--- a/Geography.kif
+++ b/Geography.kif
@@ -6404,36 +6404,6 @@ without going through the state of being a &%Liquid.")
         (MeasureFn ?Y Joule))))
   (greaterThan ?Y ?X))
   
-; 3 approximateDiameter (New)
-
-(documentation approximateDiameter EnglishLanguage "The diameter of an object if it were a
-perfect sphere of the same volume")
-
-(documentation approximateDiameter ChineseLanguage "这是假设一个为和它体积相同的完美球体的直径。")
-
-(termFormat EnglishLanguage approximateDiameter "approximate diameter")
-
-(termFormat ChineseLanguage approximateDiameter "近似直径")
-
-(domain approximateDiameter 1 SelfConnectedObject)
-
-(domain approximateDiameter 2 LengthMeasure)
-
-(instance approximateDiameter BinaryPredicate)
-
-(instance approximateDiameter SingleValuedRelation)
-
-(instance approximateDiameter TotalValuedRelation)
-
-(=>
-  (and
-    (approximateDiameter ?O ?L)
-    (sphereRadius ?S (DivisionFn ?L 2))
-    (measure ?S (MeasureFn ?V1 ?VM))
-    (measure ?O (MeasureFn ?V2 ?VM))
-    (instance ?VM VolumeMeasure))
-  (equal ?V1 ?V2))
-
 ; 4 Micrometer (New)
 
 (documentation Micrometer EnglishLanguage "Submultiple of Metre. Symbol:µm. It is a unit

--- a/Merge.kif
+++ b/Merge.kif
@@ -7886,6 +7886,10 @@ separates two distinct objects.")
 
 (instance altitude SingleValuedRelation)
 (instance altitude PartialValuedRelation)
+(domain altitude 1 Physical)
+(domain altitude 2 Physical)
+(domain altitude 3 LengthMeasure)
+
 (documentation altitude EnglishLanguage "A &%TernaryPredicate that is
 used to state the &%distance between the &%top of an &%Object and
 another point that is below the &%top of the &%Object (often this
@@ -9605,6 +9609,9 @@ is a &%part of the other.")
 (instance superficialPart IrreflexiveRelation)
 (instance superficialPart TransitiveRelation)
 (instance superficialPart PartialValuedRelation)
+(domain superficialPart 1 Object)
+(domain superficialPart 2 Object)
+
 (documentation superficialPart EnglishLanguage "(&%superficialPart ?OBJ1 ?OBJ2)
 means that ?OBJ1 is a part of ?OBJ2 that has no interior parts of its own
 (or, intuitively, that only overlaps those parts of ?OBJ2 that are
@@ -18729,6 +18736,7 @@ down commentaries ?STR on a defined &%Entity ?ENT")
 (documentation minValue EnglishLanguage "The minimum possible value for a given
 numerical argument of a &%Relation. The second argument is the argument number
 of the relation and the third argument is the minimum value.")
+(instance minValue TernaryRelation)
 (domain minValue 1 Relation)
 (domain minValue 2 Integer)
 (domain minValue 3 Quantity)
@@ -18743,6 +18751,7 @@ of the relation and the third argument is the minimum value.")
 (documentation maxValue EnglishLanguage "The maximum possible value for a given
 numerical argument of a &%Relation. The second argument is the argument number
 of the relation and the third argument is the maximum value.")
+(instance maxValue TernaryRelation)
 (domain maxValue 1 Relation)
 (domain maxValue 2 Integer)
 (domain maxValue 3 Quantity)
@@ -18758,6 +18767,7 @@ of the relation and the third argument is the maximum value.")
 (documentation defaultMinValue EnglishLanguage "The minimum likely value for a given
 numerical argument of a &%Relation. The second argument is the argument number
 of the relation and the third argument is the minimum value.")
+(instance defaultMinValue TernaryRelation)
 (domain defaultMinValue 1 Relation)
 (domain defaultMinValue 2 Integer)
 (domain defaultMinValue 3 Quantity)
@@ -18772,6 +18782,7 @@ of the relation and the third argument is the minimum value.")
 (documentation defaultMaxValue EnglishLanguage "The maximum likely value for a given
 numerical argument of a &%Relation. The second argument is the argument number
 of the relation and the third argument is the minimum value.")
+(instance defaultMaxValue TernaryRelation)
 (domain defaultMaxValue 1 Relation)
 (domain defaultMaxValue 2 Integer)
 (domain defaultMaxValue 3 Quantity)
@@ -18786,6 +18797,7 @@ of the relation and the third argument is the minimum value.")
 (documentation defaultValue EnglishLanguage "The likely value for a given
 numerical argument of a &%Relation. The second argument is the argument number
 of the relation and the third argument is the likely value.")
+(instance defaultValue TernaryRelation)
 (domain defaultValue 1 Relation)
 (domain defaultValue 2 Integer)
 (domain defaultValue 3 Quantity)

--- a/Merge.kif
+++ b/Merge.kif
@@ -13,27 +13,27 @@
 ;; New York, NY 10016-5997, USA
 ;; All rights reserved.
           
-;; 1. COPYRIGHT                                                                                                                                                                                                                                                      
+;; 1. COPYRIGHT
 ;; The Institute of Electrical and Electronics Engineers, Inc., ("IEEE") owns the         
 ;; copyright to this Document in all forms of media. Copyright in the text retrieved,     
 ;; displayed or output from this Document is owned by IEEE and is protected by the        
 ;; copyright laws of the United States and by international treaties. The IEEE reserves   
-;; all rights not expressly granted herein.                                               
-                                                                                                                                                                                
-;; 2. ROYALTIES                                                                                                                                                                                                                                                     
+;; all rights not expressly granted herein.
+
+;; 2. ROYALTIES
 ;; The IEEE is providing the Document at no charge. However, the Document is not to be    
 ;; considered "Public Domain," as the IEEE is, and at all times shall remain, the sole    
 ;; copyright holder in the Document. The IEEE intends to revise the Document from time to 
-;; time; the latest version shall be available at http://standards.ieee.org/catalog/      
-                                                                                                                                                                              
-;; 3. TERMS OF USE                                                                                                                                                                                                                                                        
+;; time; the latest version shall be available at http://standards.ieee.org/catalog/
+
+;; 3. TERMS OF USE
 ;; The IEEE hereby grants Licensee a perpetual, non-exclusive, royalty-free, world-wide   
 ;; right and license to copy, publish and distribute the Document in any way, and to      
 ;; prepare derivative works that are based on or incorporate all or part of the Document  
 ;; provided that the IEEE is appropriately acknowledged as the source and copyright owner 
-;; in each and every use.                                                                                                                                                         
-                                                                                       
-;; 4. LIMITED WARRANTIES & LIMITATIONS OF REMEDIES                                                                                                                                                                                                                        
+;; in each and every use.
+
+;; 4. LIMITED WARRANTIES & LIMITATIONS OF REMEDIES
 ;; LICENSOR Does not warrant or represent the accuracy or content of the document and     
 ;; Expressly Disclaims any Express or Implied Warranty, including any Implied Warranty of 
 ;; Merchantability or Fitness for a Specific Purpose or that the use of the document is   
@@ -6572,7 +6572,7 @@ the concept of three meters is represented as (&%MeasureFn 3
 (=>
    (and
       (instance ?REL RelationExtendedToQuantities)
-      (instance ?REL BinaryRelation)
+      (instance ?REL BinaryPredicate)
       (instance ?NUMBER1 RealNumber)
       (instance ?NUMBER2 RealNumber)
       (?REL ?NUMBER1 ?NUMBER2))
@@ -9895,10 +9895,10 @@ exactly the same things as the hole itself.")
   (exists (?HOLE2)
     (properPart ?HOLE2 ?HOLE1)))
 
-(instance HoleHostFn SpatialRelation)
+;(instance HoleHostFn SpatialRelation)
 (instance HoleHostFn UnaryFunction)
-(instance HoleHostFn TotalValuedRelation)
-(instance HoleHostFn AsymmetricRelation)
+;(instance HoleHostFn TotalValuedRelation)
+;(instance HoleHostFn AsymmetricRelation)
 (domain HoleHostFn 1 Hole)
 (range HoleHostFn Object)
 (documentation HoleHostFn EnglishLanguage "A &%UnaryFunction that maps a &%Hole to
@@ -10069,10 +10069,10 @@ in common (rather, they may occupy the same spatial region).")
     (properPart ?OBJ2 ?OBJ1))
   (properlyFills ?OBJ2 ?HOLE))
 
-(instance HoleSkinFn SpatialRelation)
+;(instance HoleSkinFn SpatialRelation)
 (instance HoleSkinFn UnaryFunction)
-(instance HoleSkinFn TotalValuedRelation)
-(instance HoleSkinFn AsymmetricRelation)
+;(instance HoleSkinFn TotalValuedRelation)
+;(instance HoleSkinFn AsymmetricRelation)
 (domain HoleSkinFn 1 Hole)
 (range HoleSkinFn Object)
 (documentation HoleSkinFn EnglishLanguage "A &%UnaryFunction that maps a &%Hole to the 
@@ -18744,6 +18744,7 @@ of the relation and the third argument is the minimum value.")
 (=>
   (and
     (minValue ?R ?ARG ?N)
+    (instance ?R Predicate)
     (?R @ARGS)
     (equal ?VAL (ListOrderFn (ListFn @ARGS) ?ARG)))
   (greaterThan ?VAL ?N))
@@ -18759,6 +18760,7 @@ of the relation and the third argument is the maximum value.")
 (=>
   (and
     (maxValue ?R ?ARG ?N)
+    (instance ?R Predicate)
     (?R @ARGS)
     (equal ?VAL (ListOrderFn (ListFn @ARGS) ?ARG)))
   (greaterThan ?N ?VAL))

--- a/Mid-level-ontology.kif
+++ b/Mid-level-ontology.kif
@@ -12845,7 +12845,7 @@ it is possible to transmit light but not through which is likely to be &%Seeing.
     (exists (?EMIT)
       (and
         (instance ?EMIT RadiatingLight)
-        (source ?EMIT ?S)
+        (resource ?EMIT ?S)
         (destination ?EMIT ?OBJ)
         (between ?S ?O ?OBJ)
         (holdsDuring 
@@ -15631,6 +15631,33 @@ disintegrated by geological processes, mixed with humus, the organic remains of 
       (instance ?Mineral Mineral)
       (part ?Humus ?Soil)
       (part ?Mineral ?Soil))))
+
+
+; 3 approximateDiameter (New)
+
+(documentation approximateDiameter EnglishLanguage "The diameter of an object if it were a
+perfect sphere of the same volume")
+(documentation approximateDiameter ChineseLanguage "这是假设一个为和它体积相同的完美球体的直径。")
+
+(termFormat EnglishLanguage approximateDiameter "approximate diameter")
+(termFormat ChineseLanguage approximateDiameter "近似直径")
+
+(domain approximateDiameter 1 SelfConnectedObject)
+(domain approximateDiameter 2 LengthMeasure)
+
+(instance approximateDiameter BinaryPredicate)
+(instance approximateDiameter SingleValuedRelation)
+(instance approximateDiameter TotalValuedRelation)
+
+(=>
+  (and
+    (approximateDiameter ?O ?L)
+    (sphereRadius ?S (DivisionFn ?L 2))
+    (measure ?S (MeasureFn ?V1 ?VM))
+    (measure ?O (MeasureFn ?V2 ?VM))
+    (instance ?VM VolumeMeasure))
+  (equal ?V1 ?V2))
+
 
 (subclass Clay Soil)
 (documentation Clay EnglishLanguage "&%Clay is fine-grained soil consisting of mineral
@@ -20412,33 +20439,6 @@ and eat.  Some restaurants may also offer entertainment.")
       (instance ?EV EducationalProcess)
       (patient ?EV ?X))))
       
-(subclass SubwaySystem RailTransportationSystem)
-(documentation SubwaySystem EnglishLanguage "Any &%RailTransportationSystem that runs 
-exclusively through &%Tunnels.")
-
-(=>
-  (and
-    (instance ?S SubwaySystem)
-    (routeInSystem ?P ?S))
-  (instance ?P Tunnel))
-
-(=>
-  (instance ?X SubwaySystem)
-  (exists (?SURF)
-    (and
-      (surface ?SURF GeographicArea)
-      (orientation ?X ?SURF Below))))
-      
-(=>
-  (instance ?X SubwaySystem)
-  (hasPurpose ?X
-    (exists (?EV ?P)
-      (and
-        (instance ?EV Transportation)
-        (instance ?P Human)
-        (patient ?EV ?P)
-        (eventLocated ?EV ?X)))))
-        
 (instance Tourist SocialRole)
 (documentation Tourist EnglishLanguage "A tourist is a
 person who is travelling to a place primarily for reasons of
@@ -23451,6 +23451,55 @@ with dirt, dust or grime")
   (instance ?X Object))
   
 (contraryAttribute Dirty Clean)
+
+
+(instance shape BinaryPredicate)
+(subrelation shape property)
+(domain shape 1 Physical)
+(domain shape 2 ShapeAttribute)
+(documentation shape EnglishLanguage "(shape ?OBJECT ?SHAPE) means that the shape of ?OBJECT is ?SHAPE.")
+
+; If a &%Physical object has a property which is an instance of &%ShapeAttribute,
+; then that object has that shape:
+
+(=>
+  (and
+    (property ?OBJ ?SHAPE)
+    (instance ?OBJ Physical)
+    (instance ?SHAPE ShapeAttribute))
+  (shape ?OBJ ?SHAPE))
+
+(instance RoundTwoDimensional ShapeAttribute)
+(documentation RoundTwoDimensional EnglishLanguage "The attribute of being round in two dimensions.")
+
+(instance Elliptical ShapeAttribute)
+(subAttribute Elliptical RoundTwoDimensional)
+(documentation Elliptical EnglishLanguage "The attribute of being elliptical or oval in two dimensions.")
+
+(=>
+  (instance ?SHAPE Oval)
+  (shape ?SHAPE Elliptical))
+
+(instance Circular ShapeAttribute)
+(subAttribute Circular RoundTwoDimensional)
+(documentation Circular EnglishLanguage "The attribute of being circular in two dimensions.")
+
+(=>
+  (instance ?SHAPE Circle)
+  (shape ?SHAPE Circular))
+
+(instance DiskShaped ShapeAttribute)
+(documentation DiskShaped EnglishLanguage "The attribute of being circular in one dimension and flat in the other.")
+(subAttribute DiskShaped Circular)
+(subAttribute DiskShaped Flat)
+
+(subclass SphericalObject Object)
+(documentation SphericalObject EnglishLanguage "An object with the attribute of being spherical.")
+
+(=>
+  (instance ?SPHERE SphericalObject)
+  (shape ?SHAPE Sphere))
+
 
 (subclass DataStorageDevice Device)
 (documentation DataStorageDevice EnglishLanguage "An &%instance of
@@ -28709,7 +28758,7 @@ their &%birthplace or where the &%Residence they &%inhabit is &%located.")
       (and
         (instance ?P Eating)
         (agent ?P ?H)
-        (termporallyOverlaps ?T (WhenFn ?P))))))
+        (overlapsTemporally ?T (WhenFn ?P))))))
 
 (instance Dieting RelationalAttribute)
 (documentation Dieting EnglishLanguage "A state of reducing one's normal or desired intake of &%Food.")

--- a/Transportation.kif
+++ b/Transportation.kif
@@ -312,6 +312,33 @@ other than broad, dual, narrow, or standard gauge is the &%LengthMeasure
       (instance ?RAILWAY Railway)
       (located ?RAILWAY ?AREA))))
 
+(subclass SubwaySystem RailTransportationSystem)
+(documentation SubwaySystem EnglishLanguage "Any &%RailTransportationSystem that runs 
+exclusively through &%Tunnels.")
+
+(=>
+  (and
+    (instance ?S SubwaySystem)
+    (routeInSystem ?P ?S))
+  (instance ?P Tunnel))
+
+(=>
+  (instance ?X SubwaySystem)
+  (exists (?SURF)
+    (and
+      (surface ?SURF GeographicArea)
+      (orientation ?X ?SURF Below))))
+      
+(=>
+  (instance ?X SubwaySystem)
+  (hasPurpose ?X
+    (exists (?EV ?P)
+      (and
+        (instance ?EV Transportation)
+        (instance ?P Human)
+        (patient ?EV ?P)
+        (eventLocated ?EV ?X)))))
+
 (subclass Railway LandTransitway) ;; &%Transitway is defined in Part II.
 (subclass Railway StationaryArtifact)
 (documentation Railway EnglishLanguage "&%Railway is the subclass of 

--- a/development/HOL.kif
+++ b/development/HOL.kif
@@ -65,8 +65,8 @@
 (=>
   (and
     (hasAuthorityOver ?AUTH ?AG)
-    (confersObligation ?F ?AUTH ?AG)))
-  (desires ?AG ?F)))
+    (confersObligation ?F ?AUTH ?AG))
+  (desires ?AG ?F))
 
 ;; Prob4
 (=>


### PR DESCRIPTION

Typically we don't load all kif files. During my experiments with the Banana Slug reasoning (see #163), I  am using only the Merge.kif, Mid-level-ontology.kif and banana.kif. 

The conversion with only those files reveals some uses of predicates in Mid-level-ontoloy.kif and Merge.kif defined in domain specific kif files. I moved the definitions.

I have added some `domain` declarations.

I have added some arity declarations.

The aximos about `SubwaySystem` where moved to `Transportation.kif`. 

