### PR TITLE
Fix typo in duration documentation

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -7372,7 +7372,7 @@ all other &%TimePoints.")
 (domain duration 2 TimeDuration)
 
 (documentation duration EnglishLanguage "(&%duration ?POS ?TIME) means that the
-duration of the &%TimePosition ?POS is ?TIME.  Note that this
+duration of the &%TimeInterval ?POS is ?TIME.  Note that this
 &%Predicate can be used in conjunction with the &%Function &%WhenFn
 to specify the duration of any instance of &%Physical.")
 


### PR DESCRIPTION
Rename `&%TimeInterval ?POS` to `&%TimeInterval ?POS` in `documentation` for `duration`