### PR TITLE
Make ProbabilityFn not be an instance of AsymmetricRelation

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -2472,7 +2472,6 @@ permit assessment of the probability of an event or situation.")
 (instance ProbabilityFn UnaryFunction)
 (domain ProbabilityFn 1 Formula)
 (range ProbabilityFn RealNumber)
-(instance ProbabilityFn AsymmetricRelation)
 
 (documentation ProbabilityFn EnglishLanguage "One of the basic &%ProbabilityRelations,
 &%ProbabilityFn is used to state the a priori probability of a state of


### PR DESCRIPTION
Make `ProbabilityFn` no longer be an instance of `AsymmetricRelation` since `AsymmetricRelation` is a subclass of `BinaryRelation` which conflicts with `ProbabilityFn` being a unary function.