### PR TITLE
Define SubtractionFn,DivisionFn as non-associative

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -4400,7 +4400,6 @@ numbers.")
   (equal (SuccessorFn ?NUMBER) (AdditionFn ?NUMBER 1)))
 
 (instance SubtractionFn BinaryFunction)
-(instance SubtractionFn AssociativeFunction)
 ;(instance SubtractionFn RelationExtendedToQuantities)
 (instance SubtractionFn TotalValuedRelation)
 (domain SubtractionFn 1 Quantity)
@@ -4417,7 +4416,6 @@ exception occurs when ?NUMBER1 is equal to 0, in which case
   (equal (PredecessorFn ?NUMBER) (SubtractionFn ?NUMBER 1)))
 
 (instance DivisionFn BinaryFunction)
-(instance DivisionFn AssociativeFunction)
 ;(instance DivisionFn RelationExtendedToQuantities)
 (instance DivisionFn PartialValuedRelation)
 (domain DivisionFn 1 Quantity)


### PR DESCRIPTION
By definition (https://en.wikipedia.org/wiki/Associative_property#Definition) binary operations such as subtraction and division don't satisfy associative law.

>Proof:
>* Subtraction
>(7 - 3) - 2 ≠ 7 - (3 - 2)
>* Division
>(8 / 4) / 2 ≠ 8 / (4 / 2)
