### PR TITLE
Dropping a weird Schadenfruede rule (and aligning documentation with the actual rules).

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -17759,7 +17759,7 @@ every part of the &%Object has a subpart which is a &%Liquid.")
 
 (subclass BiologicalAttribute InternalAttribute)
 (documentation BiologicalAttribute EnglishLanguage "&%Attributes that apply specifically
-to instances of &%Organism.")
+to instances of &%OrganicObject (&%Organism or &%AnatomicalStructure).")
 
 ;; NS: delete.  Many current instances of BiologicalAttribute apply
 ;; to OrganicObjects that are not Organisms.

--- a/emotion.kif
+++ b/emotion.kif
@@ -784,14 +784,6 @@ happiness, enjoyment, and satisfaction. [Source: OCEAS]")
 (termFormat SpanishLanguage Pleasure "placer")
 (utterance EnglishLanguage Pleasure "pleased")
 
-(=>
-  (attribute ?A Pleasure)
-  (exists (?P)
-    (and
-      (causesProposition ?P  
-        (attribute ?A Schadenfreude))
-      (desires ?A ?P))))
-
 (utterance EnglishLanguage SensoryPleasure "sensory pleasure")
 (termFormat EnglishLanguage SensoryPleasure "sensory pleasure")
 (documentation SensoryPleasure EnglishLanguage "Pleasure in smell,


### PR DESCRIPTION
Feel free to drop the OrganicObject update if it's ugly.  I found this confusing when climbing the class ladder for DiseaseOrSyndrome.