### PR TITLE
Solely fix

### DIFF
--- a/Mid-level-ontology.kif
+++ b/Mid-level-ontology.kif
@@ -30303,17 +30303,17 @@ an object.  Note that this would exclude cases where some damage occurred and wa
 (documentation Solely EnglishLanguage "A &%manner of action in which only one &%AutonomousAgent participated.")
 
 (=>
-    (manner ?P Solely)
-    (exists (?H)
-        (and
-            (involvedInEvent ?P ?H)
-            (instance ?H AutonomousAgent)
-            (not
-                (exists (?H2)
-                    (and
-                        (involvedInEvent ?P ?H2)
-                        (instance ?H2 AutonomousAgent)
-                        (not (equal ?H ?H2))))))))
+  (manner ?P Solely)
+  (exists (?H)
+    (and
+      (involvedInEvent ?P ?H)
+      (instance ?H AutonomousAgent)
+      (not
+        (exists (?H2)
+          (and
+            (involvedInEvent ?P ?H2)
+            (instance ?H2 AutonomousAgent)
+            (not (equal ?H ?H2))))))))
 
 (instance Alone RelationalAttribute)
 (documentation Alone EnglishLanguage "A state of being without another &%AutonomousAgent present.")

--- a/Mid-level-ontology.kif
+++ b/Mid-level-ontology.kif
@@ -30303,17 +30303,17 @@ an object.  Note that this would exclude cases where some damage occurred and wa
 (documentation Solely EnglishLanguage "A &%manner of action in which only one &%AutonomousAgent participated.")
 
 (=>
-  (manner ?P Solely)
-  (and
+    (manner ?P Solely)
     (exists (?H)
-      (and
-        (involvedInEvent ?P ?H)
-        (instance ?H AutonomousAgent)))
-    (not
-      (exists (?H2)
         (and
-          (involvedInEvent ?P ?H2)
-          (instance ?H2 AutonomousAgent))))))
+            (involvedInEvent ?P ?H)
+            (instance ?H AutonomousAgent)
+            (not
+                (exists (?H2)
+                    (and
+                        (involvedInEvent ?P ?H2)
+                        (instance ?H2 AutonomousAgent)
+                        (not (equal ?H ?H2))))))))
 
 (instance Alone RelationalAttribute)
 (documentation Alone EnglishLanguage "A state of being without another &%AutonomousAgent present.")


### PR DESCRIPTION
The old def had ?H and ?H2 in different scopes in a way that amounted to (And E ~E).  This definition should be what was intended, I think.