### PR TITLE
Replacing patient in Judging with result for the result of the judgment.

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -11991,7 +11991,7 @@ him/her.")
    (and
       (instance ?JUDGE Judging)
       (agent ?JUDGE ?AGENT)
-      (patient ?JUDGE ?PROPOSITION))
+      (result ?JUDGE ?PROPOSITION))
    (and
       (holdsDuring (BeginFn (WhenFn ?JUDGE)) (not (believes ?AGENT ?PROPOSITION)))
       (holdsDuring (EndFn (WhenFn ?JUDGE)) (believes ?AGENT ?PROPOSITION))))
@@ -17223,7 +17223,7 @@ this &%Class.")
           (instance ?JUDGE Judging)
           (agent ?JUDGE ?AGENT)
           (patient ?JUDGE ?OBJ)
-          (patient ?JUDGE
+          (result ?JUDGE
                 (attribute ?OBJ ?ATR))
           (holdsDuring ?TIME
             (believes ?AGENT


### PR DESCRIPTION
Given result is a subrelation of patient, I think it makes sense to use result to denote the selected belief).  There's one case of this with contestObject.  It seems more clear because any belief considered could be a patient as well as the entity that is being judged.