### PR TITLE
Small type error fix

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -8236,6 +8236,8 @@ have a &%TimeInterval as a common part.")
    (and
       (instance ?REL BinaryPredicate)
       (instance ?REL SpatialRelation)
+      (instance ?OBJ1 Physical)
+      (instance ?OBJ2 Physical)
       (?REL ?OBJ1 ?OBJ2))
    (overlapsTemporally (WhenFn ?OBJ1) (WhenFn ?OBJ2)))
 


### PR DESCRIPTION
Looks like the "typicalPart" family fits the preconditions for this rule yet is a relation over subclasses.  One fix is to just specify that they objects.  (Maybe this is the kind of error that doesn't need to be fixed, however ^^;)

KBcache.checkDisjoint(): mixing class and instance: Object+, Physical
SUMOtoTFAform.inconsistentVarTypes(): rejected inconsistent variable types: Object+, Physical for var ?OBJ1
SUMOtoTFAform.process(): rejected inconsistent variables types: {?OBJ1=[Object+, Physical, Class], ?OBJ2=[Object+, Physical, Class]} in : (=>
  (and
    (subclass ?OBJ1 Object)
    (instance ?OBJ1 Physical)
    (subclass ?OBJ2 Object)
    (instance ?OBJ2 Physical))
  (=>
    (and
      (instance partTypes BinaryPredicate)
      (instance partTypes SpatialRelation)
      (partTypes ?OBJ1 ?OBJ2))
    (overlapsTemporally
      (WhenFn ?OBJ1)
      (WhenFn ?OBJ2))))
