### PR TITLE
Add manual job

### DIFF
--- a/.github/workflows/sumo-ci.yml
+++ b/.github/workflows/sumo-ci.yml
@@ -6,7 +6,7 @@ on:
       vampire_timeout:
         description: 'How long vampire should run'
         required: true
-        type: number
+        type: string
 
 env:
   DEFAULT_DOCKER_ACCOUNT: apease

--- a/.github/workflows/sumo-dev-cycle.yml
+++ b/.github/workflows/sumo-dev-cycle.yml
@@ -10,4 +10,4 @@ jobs:
    call-sumo-check-workflow:
     uses: ./.github/workflows/sumo-ci.yml
     with:
-      vampire_timeout: 900
+      vampire_timeout: '900'

--- a/.github/workflows/sumo-manual.yml
+++ b/.github/workflows/sumo-manual.yml
@@ -1,0 +1,28 @@
+name: SUMO Manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      vampire_timeout_minutes:
+        description: 'How long vampire should run in minutes'
+        required: true
+        type: number
+        default: 180
+
+jobs:
+  derive_vampire_timeout:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      vampire_timeout: ${{ steps.step1.outputs.vampire_timeout }}
+    steps:
+      - id: step1
+        env:
+          VAMPIRE_TIMEOUT_MINUTES: ${{ inputs.vampire_timeout_minutes }}
+        run: echo "vampire_timeout=$((VAMPIRE_TIMEOUT_MINUTES * 60))" >> "$GITHUB_OUTPUT"
+
+  call-sumo-check-workflow:
+    needs: derive_vampire_timeout
+    uses: ./.github/workflows/sumo-ci.yml
+    with:
+      vampire_timeout: ${{ needs.derive_vampire_timeout.outputs.vampire_timeout }}

--- a/.github/workflows/sumo-scheduled.yml
+++ b/.github/workflows/sumo-scheduled.yml
@@ -9,4 +9,4 @@ jobs:
     if: github.repository == 'ontologyportal/sumo'
     uses: ./.github/workflows/sumo-ci.yml
     with:
-      vampire_timeout: 10800
+      vampire_timeout: '10800'


### PR DESCRIPTION
Add a manual job so workflow can be triggered at any time.
GH has limitations around passing numbers between jobs so `vampire_timeout` type had to be changed to string.