### PR TITLE
fixed ratingsAgent definition to be more coherent with the usage of r…

### DIFF
--- a/Hotel.kif
+++ b/Hotel.kif
@@ -3002,22 +3002,25 @@ by an &%AutonomousAgent with some criteria in mind.")
 ;; underwent some decision-making to come up with that rating
 (=>
   (instance ?RATING RatingAttribute)
-  (exists (?AGENT)
-    (ratingsAgent ?RATING ?AGENT)))
+  (exists (?AGENT ?OBJ)
+    (and 
+      (ratingsAgent ?RATING ?AGENT)
+      (attribute ?OBJ ?RATING))))
 
 ;;(ratingsAgent ?RATING ?AGENT)
 (instance ratingsAgent BinaryPredicate)      
 (documentation ratingsAgent EnglishLanguage "(&%ratingsAgent ?RATING ?AGENT) means that ?AGENT went 
-through some &%Deciding process in order to create &%RatingAttribute ?RATING.")
+through some &%Classifying process in order to create &%RatingAttribute ?RATING.")
 (domain ratingsAgent 1 RatingAttribute)
 (domain ratingsAgent 2 AutonomousAgent)
 
 (=>
   (ratingsAgent ?RATING ?AGENT)
-  (exists (?PROCESS)
+  (exists (?PROCESS ?OBJ)
     (and
-      (instance ?PROCESS Deciding)
+      (instance ?PROCESS Classifying)
       (agent ?PROCESS ?AGENT)
+      (destination ?PROCESS ?OBJ)
       (result ?PROCESS ?RATING))))
  
 (subclass HotelRating RatingAttribute)


### PR DESCRIPTION
The rules and definition surrounding Deciding are confusing.

I was going to make this Judging but looking through Hotel.kif, it seems the subclasses of RatingAttribute imply a Classifying process.  So I decided to do the same.

I think the RatingAttribute should imply the existence of an object to which the rating is assigned and not just the agent.

(I think this is the second to last of the "possible bugs" I logged during my work 🙂.)