### PR TITLE
instance -> element

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -4265,13 +4265,13 @@ from having the right to use or be located at a particular object, for example, 
 &%Set of &%Objects owned by the &%AutonomousAgent.")
 
 (=>
-  (instance ?OBJ
+  (element ?OBJ
     (PropertyFn ?PERSON))
   (possesses ?PERSON ?OBJ))
 
 (=>
   (possesses ?PERSON ?OBJ)
-  (instance ?OBJ
+  (element ?OBJ
     (PropertyFn ?PERSON)))
 
 (instance precondition BinaryPredicate)


### PR DESCRIPTION
I think this is the only instance of the bug :- ).

I noticed an additional bug requiring summing the monetary value of each element of the set.  I'll save that fix for later ^^;

(domain monetaryValue 1 Physical)
(=>
  (equal
    (WealthFn ?PERSON) ?AMOUNT)
  (monetaryValue
    (PropertyFn ?PERSON) ?AMOUNT))

(=>
  (monetaryValue
    (PropertyFn ?PERSON) ?AMOUNT)
  (equal
    (WealthFn ?PERSON) ?AMOUNT))