### PR TITLE
Disable `loadVampire`

### DIFF
--- a/.github/workflows/sumo-ci.yml
+++ b/.github/workflows/sumo-ci.yml
@@ -50,15 +50,16 @@ jobs:
         sed -i "s|/home/theuser/workspace/sumo|$ONTOLOGYPORTAL_GIT/sumo|g" $SIGMA_HOME/KBs/config.xml
         sed -i "s|/home/theuser/E/bin/e_ltb_runner|/usr/local/bin/e_ltb_runner|g" $SIGMA_HOME/KBs/config.xml
         sed -i "s|/home/theuser/workspace/vampire/vampire|/usr/local/bin/vampire|g" $SIGMA_HOME/KBs/config.xml
+        sed -i 's|preference name="TPTP" value="yes"|preference name="TPTP" value="no"|g' $SIGMA_HOME/KBs/config.xml
 
-    - name: Produce SUMO.tptp
+    - name: Produce SUMO.fof
       run: java -Xmx8g -classpath "/root/sigmakee/*" com.articulate.sigma.trans.SUMOKBtoTPTPKB
 
-    - name: Upload SUMO.tptp
+    - name: Upload SUMO.fof
       uses: actions/upload-artifact@v3
       with:
-        name: SUMO.tptp
-        path: ${{ env.SIGMA_HOME }}/KBs/SUMO.tptp
+        name: SUMO.fof
+        path: ${{ env.SIGMA_HOME }}/KBs/SUMO.fof
 
   run_vampire:
     runs-on: ubuntu-latest
@@ -71,15 +72,15 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: SUMO.tptp
+        name: SUMO.fof
 
-    - name: Run vampire against SUMO.tptp
+    - name: Run vampire against SUMO.fof
       env:
         VAMPIRE_TIMEOUT: ${{ inputs.vampire_timeout }}
       run: |
         ls -l .
         echo "VAMPIRE_TIMEOUT: $VAMPIRE_TIMEOUT"
-        /usr/local/bin/vampire --proof tptp -t $VAMPIRE_TIMEOUT SUMO.tptp > vamp-out.txt || echo "Ignoring vampire exit code"
+        /usr/local/bin/vampire --proof tptp -t $VAMPIRE_TIMEOUT SUMO.fof > vamp-out.txt || echo "Ignoring vampire exit code"
         mkdir -p $SIGMA_HOME/webapps/sigma/graph
         CATALINA_HOME=$SIGMA_HOME java -Xmx8g -classpath "/root/sigmakee/*" com.articulate.sigma.trans.TPTP3ProofProcessor -f vamp-out.txt
         cp $SIGMA_HOME/webapps/sigma/graph/proof.* .


### PR DESCRIPTION
TPTP output produced twice during SUMOKBtoTPTPKB.
For details please check [disable-loadVampire](https://github.com/ontologyportal/sigmakee/issues/96)

This change disables code branch which creates `SUMO.TPTP` during startup.

Previous CI config had a bug where it relied on `SUMO.TPTP` rather than on `SUMO.fof`
Now, since `SUMO.TPTP` is not produced anymore config has to be fixed to use `SUMO.fof`.