### PR TITLE
fixed documentation errors for &%CoffeePlant

### DIFF
--- a/Economy.kif
+++ b/Economy.kif
@@ -4430,15 +4430,16 @@ often juiced. The plant ranks as one of the world's most valuable and
 widely traded commodity crops and is an important export product of
 several countries, including those in Central and South America, the
 Caribbean and Africa.[from Wikipedia]")
+(names "coffea plant" CoffeePlant)
 
 (subclass CoffeaArabica CoffeePlant)
-(documentation CoffeaArabica EnglishLanguage "&%CoffeaArabica is a subclass of &%CoffeaPlant,
+(documentation CoffeaArabica EnglishLanguage "&%CoffeaArabica is a subclass of &%CoffeePlant,
  representing about 60% of global production. It is more acidic, less bitter and contained less 
  &%Caffeine (~1.5%) than &%CoffeaRobusta plant.[Wikipedia]")
 (termFormat EnglishLanguage CoffeaArabica "coffea arabica")
 
 (subclass CoffeaRobusta CoffeePlant)
-(documentation CoffeaRobusta EnglishLanguage "&%CoffeaRobusta is a subclass of &%CoffeaPlant,
+(documentation CoffeaRobusta EnglishLanguage "&%CoffeaRobusta is a subclass of &%CoffeePlant,
  representing about 40% of global production. It is less acidic, more bitter and contained more 
  &%Caffeine(~2.7%) than &%CoffeaArabica plant.[Wikipedia]")
 (termFormat EnglishLanguage CoffeaRobusta "coffea robusta")
@@ -4446,7 +4447,7 @@ Caribbean and Africa.[from Wikipedia]")
 
 (subclass CoffeeBean Seed)
 (subclass CoffeeBean FoodFromPlant)
-(documentation CoffeeBean EnglishLanguage "A &%CoffeeBean is a seed of the &%CoffeaPlant
+(documentation CoffeeBean EnglishLanguage "A &%CoffeeBean is a seed of the &%CoffeePlant
 and the source for coffee.")
 
 (=>
@@ -4458,7 +4459,7 @@ and the source for coffee.")
 
 (subclass CoffeeArabica CoffeeBean)
 (documentation CoffeeArabica EnglishLanguage "&%CoffeeArabica are &%CoffeeBeans harvested from 
-&%CoffeaArabic &%CoffeaPlant. Arabica beans consist of 0.8–1.4% caffeine.[Wikipedia]")
+&%CoffeaArabic &%CoffeePlant. Arabica beans consist of 0.8–1.4% caffeine.[Wikipedia]")
 (termFormat EnglishLanguage CoffeeArabica "coffee arabica")
 
 (=>
@@ -4482,7 +4483,7 @@ and the source for coffee.")
 
 (subclass CoffeeRobusta CoffeeBean)
 (documentation CoffeeRobusta EnglishLanguage "&%CoffeeRobusta are &%CoffeeBeans harvested from 
-&%CoffeaRobusta &%CoffeaPlant. Arabica beans consist of 1.7-4.0% caffeine.[Wikipedia]")
+&%CoffeaRobusta &%CoffeePlant. Arabica beans consist of 1.7-4.0% caffeine.[Wikipedia]")
 (termFormat EnglishLanguage CoffeeRobusta "coffee robusta")
 
 (=>


### PR DESCRIPTION
Dear Adam

Please find the fix regarding documentation on &%CoffeePlant. 
The class name is CoffeePlant. I am sorry that I have made a typo within the documentation string in using &%CoffeaPlant. It should be &%CoffeePlant. I have also added the names relation to link the string"coffea plant" to CoffeePlant.

Please check and merge.

Jennie