### PR TITLE
Change cellShape from subclass to instance of BinaryPredicate

### DIFF
--- a/VirusProteinAndCellPart.kif
+++ b/VirusProteinAndCellPart.kif
@@ -348,7 +348,7 @@ molecules.")
    (instance ?OBJ2 CellNucleus)
    (part ?OBJ2 ?OBJ1)))))
 
-(subclass cellShape BinaryPredicate)
+(instance cellShape BinaryPredicate)
 (subrelation cellShape shape)
 (domainSubclass cellShape 1 Cell)
 (domain cellShape 2 ShapeAttribute)


### PR DESCRIPTION
cellShape was a `subclass` or BinaryPredicate
But most of other usages of BinaryPredicate is `instance`