### PR TITLE
Fix capability arg3 declaration: domain -> domainSubclass

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -3938,7 +3938,7 @@ that this implies that ?FORMULA is true at every &%TimePoint which is a
 (instance capability TernaryPredicate)
 (domainSubclass capability 1 Process)
 (domain capability 2 CaseRole)
-(domain capability 3 Object)
+(domainSubclass capability 3 Object)
 
 (documentation capability EnglishLanguage "(&%capability ?PROCESS ?ROLE ?OBJ) means
 that ?OBJ has the ability to play the role of ?ROLE in &%Processes of


### PR DESCRIPTION
## Problem

`capability` is declared in Merge.kif with the following domain constraints:

```
(instance capability TernaryPredicate)     ; Merge.kif:3938
(domainSubclass capability 1 Process)      ; Merge.kif:3939
(domain capability 2 CaseRole)             ; Merge.kif:3940
(domain capability 3 Object)              ; Merge.kif:3941  ← incorrect
```

Arg3 is declared with `domain` (requires an instance of Object), but all standard usage passes a **class** as arg3. The `domainSubclass` declaration on arg1 confirms the intended pattern: arg1 takes a class (subclass of Process), and arg3 should likewise take a class (subclass of Object).

## Reproducible Examples

From `development/Objects.kif` (jdev-02/sumo):

```
development/Objects.kif:27   (capability Poking instrument Tine)
development/Objects.kif:28   (capability Piercing instrument Tine)
development/Objects.kif:113  (capability Eating instrument Bowl)
development/Objects.kif:165  (capability Eating instrument Spoon)
development/Objects.kif:233  (capability Cutting instrument Scissors)
development/Objects.kif:234  (capability Shearing instrument Scissors)
development/Objects.kif:277  (capability Eating instrument Fork)
development/Objects.kif:312  (capability Eating instrument Plate)
development/Objects.kif:341  (capability Drinking instrument DiningCup)
development/Objects.kif:403  (capability Translocation instrument Bucket)
development/Objects.kif:429  (capability Translocation instrument Backpack)
development/Objects.kif:493  (capability Digging instrument Shovel)
```

From `development/Animals.kif` (jdev-02/sumo):

```
development/Animals.kif:677   (capability Swimming agent Capybara)
development/Animals.kif:729   (capability Hunting agent Wolf)
development/Animals.kif:792   (capability Echolocation agent Dolphin)
development/Animals.kif:833   (capability Swimming agent Whale)
development/Animals.kif:1109  (capability Climbing agent Gorilla)
development/Animals.kif:1442  (capability Making agent Crow)
development/Animals.kif:1565  (capability Making agent Beaver)
development/Animals.kif:1986  (capability Hunting agent Cobra)
```

Every one of these assertions is valid by the documented semantics of `capability` but fails domain checking under the current `domain` declaration.

## Fix

Change Merge.kif:3941 from:

```
(domain capability 3 Object)
```

to:

```
(domainSubclass capability 3 Object)
```

This aligns the formal declaration with arg1's existing `domainSubclass` treatment and with the standard usage pattern throughout the corpus.

## Environment

- Ubuntu 24.04.3 LTS (WSL2, kernel 6.6.87.2-microsoft-standard-WSL2)
- OpenJDK 21.0.10
- Vampire 5.0.1 (commit ec9595e79, 2026-01-27)
- SigmaKEE current master