### PR TITLE
Fix Medicine.kif: replace undefined Pounds with PoundMass in blood volume rule

### DIFF
--- a/Medicine.kif
+++ b/Medicine.kif
@@ -5908,7 +5908,7 @@ or 1060 kg/m3 (Wikipedia) and 7 percent of a &%HumanAdult's weight.")
   (and
     (instance ?H HumanAdult)
     (measure ?H
-      (MeasureFn ?N Pounds)))
+      (MeasureFn ?N PoundMass)))
   (and
     (bloodVolume ?H (MeasureFn ?N2 Liter))
     (equal ?N2


### PR DESCRIPTION
Medicine.kif:5911 uses Pounds in the blood volume estimation rule, but Pounds is not a defined term in SUMO. The correct term is PoundMass, which is defined in Merge.kif and used consistently across 23+ other files. One-line fix replacing Pounds with PoundMass.

Environment: Ubuntu 24.04.3 LTS (WSL2), OpenJDK 21.0.10, SigmaKEE current master.