### PR TITLE
Add CubicFn unary function to Merge.kif

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -5278,6 +5278,17 @@ square root of ?NUMBER.")
    (equal (SquareRootFn ?NUMBER1) ?NUMBER2)
    (equal (MultiplicationFn ?NUMBER2 ?NUMBER2) ?NUMBER1))
 
+(instance CubicFn UnaryFunction)
+(domain CubicFn 1 RealNumber)
+(range CubicFn RealNumber)
+
+(documentation CubicFn EnglishLanguage "(CubicFn ?NUMBER) is the cube of ?NUMBER,
+i.e. ?NUMBER raised to the power of 3.")
+
+(=>
+   (equal (CubicFn ?NUMBER1) ?NUMBER2)
+   (equal (MultiplicationFn ?NUMBER1 (MultiplicationFn ?NUMBER1 ?NUMBER1)) ?NUMBER2))
+
 (instance TangentFn UnaryFunction)
 (instance TangentFn TotalValuedRelation)
 (domain TangentFn 1 RealNumber)


### PR DESCRIPTION
CubicFn is missing from SUMO, meaning cubic quantities currently require nested MultiplicationFn calls rather than a clean functional term. This adds CubicFn as a UnaryFunction on RealNumber, inserted after SquareRootFn in the math functions section (Merge.kif:5279), following the same declaration and axiom pattern. The axiom grounds CubicFn in terms of MultiplicationFn: the cube of N equals N * (N * N).

SquareUnitFn exists in Mid-level-ontology.kif for square unit conversion (line 15091) but there is no CubicUnitFn or CubicFn anywhere in the corpus. This fills that gap.

Environment: Ubuntu 24.04.3 LTS (WSL2), OpenJDK 21.0.10, SigmaKEE current master.