### PR TITLE
Improve Objects.kif: Scissors through DiningCup (part 2)

### DIFF
--- a/Objects.kif
+++ b/Objects.kif
@@ -297,16 +297,16 @@
     (MohsScaleFn ?PMAT)))
     
 
-(subclass Scissors CuttingDevice)
 (subclass Scissors HandTool)
+
 (termFormat EnglishLanguage Scissors "scissors")
 (documentation Scissors EnglishLanguage "A &%CuttingDevice consisting
-of two blades joined at a pivot point and operated by a handle on
-each blade, so that opening and closing the handles drives the blades
-across each other to cut material. Unlike a &%Knife, which cuts by
-drawing a single blade across a surface, scissors cut by the shearing
-action of two opposing blades. &%Scissors are used to cut paper,
-fabric, hair, and other thin materials.")
+  of two &%Blade components joined at a pivot &%Screw and operated by a &%Handle on
+  each blade, so that opening and closing the handles drives the blades
+  across each other to cut material. Unlike a &%Knife, which cuts by
+  drawing a single blade across a surface, &%Scissors cut by the &%Shearing
+  action of two opposing blades. &%Scissors are used to cut paper,
+  fabric, hair, and other thin materials.")
 
 (=>
   (and
@@ -321,18 +321,43 @@ fabric, hair, and other thin materials.")
 (=>
   (instance ?SCIS Scissors)
   (hasPurpose ?SCIS
-    (exists (?CUT)
+    (exists (?SHR)
       (and
-        (instance ?CUT Cutting)
-        (instrument ?CUT ?SCIS)))))
+        (instance ?SHR Shearing)
+        (instrument ?SHR ?SCIS)))))
 
-(increasesLikelihood
+(=>
   (instance ?S Scissors)
-  (material Metal ?S))
+  (modalAttribute
+    (material Metal ?S) Likely))
 
-(=> (instance ?S Scissors) (attribute ?S Rigid))
+(=>
+  (instance ?S Scissors)
+  (attribute ?S Rigid))
 
-(=> (instance ?S Scissors) (exists (?H) (and (instance ?H Handle) (part ?H ?S))))
+(=>
+  (instance ?S Scissors)
+  (exists (?H)
+    (and
+      (instance ?H Handle)
+      (part ?H ?S))))
+
+(=>
+  (instance ?S Scissors)
+  (exists (?B1 ?B2)
+    (and
+      (instance ?B1 Blade)
+      (instance ?B2 Blade)
+      (part ?B1 ?S)
+      (part ?B2 ?S)
+      (not (equal ?B1 ?B2)))))
+
+(=>
+  (instance ?S Scissors)
+  (exists (?SC)
+    (and
+      (instance ?SC Screw)
+      (part ?SC ?S))))
 
 (increasesLikelihood
   (and
@@ -347,18 +372,106 @@ fabric, hair, and other thin materials.")
         (instance ?P Fabric)))))
 
 (capability Cutting instrument Scissors)
+(capability Shearing instrument Scissors)
 
+(subclass KitchenShears Scissors)
 
-;; Not in Merge.kif or Dining.kif.
+(termFormat EnglishLanguage KitchenShears "kitchen shears")
+(documentation KitchenShears EnglishLanguage "&%KitchenShears are &%Scissors
+  designed for food preparation, used to cut &%Food items such as poultry
+  and herbs.  &%KitchenShears inherit the two-&%Blade pivot-&%Screw structure
+  of &%Scissors but are heavier and more durable, suited for cutting dense
+  or moist food material.")
+
+(=>
+  (instance ?KS KitchenShears)
+  (hasPurpose ?KS
+    (exists (?CUT ?FOOD)
+      (and
+        (instance ?CUT Cutting)
+        (instrument ?CUT ?KS)
+        (instance ?FOOD Food)
+        (patient ?CUT ?FOOD)))))
+
+(increasesLikelihood
+  (and
+    (instance ?KS KitchenShears)
+    (instance ?CUT Cutting)
+    (instrument ?CUT ?KS))
+  (exists (?FOOD)
+    (and
+      (instance ?FOOD Food)
+      (patient ?CUT ?FOOD))))
+
+(capability Cutting instrument KitchenShears)
+(capability Shearing instrument KitchenShears)
+
+(subclass PruningShears CuttingDevice)
+(subclass PruningShears HandTool)
+
+(termFormat EnglishLanguage PruningShears "pruning shears")
+(documentation PruningShears EnglishLanguage "A &%CuttingDevice consisting of two
+  &%Blade components joined at a pivot &%Screw, designed to cut plant stems,
+  branches, and other botanical material by &%Shearing action.  Like &%Scissors,
+  &%PruningShears cut by the coordinated action of two opposing blades; unlike
+  &%Scissors, they are sized and hardened for cutting live or woody &%Plant tissue.
+  The typical patient of a &%PruningShears operation is &%PlantMatter.")
+
+(=>
+  (instance ?PS PruningShears)
+  (attribute ?PS Rigid))
+
+(=>
+  (instance ?PS PruningShears)
+  (modalAttribute
+    (material Metal ?PS) Likely))
+
+(=>
+  (instance ?PS PruningShears)
+  (exists (?H)
+    (and
+      (instance ?H Handle)
+      (part ?H ?PS))))
+
+(=>
+  (instance ?PS PruningShears)
+  (exists (?B1 ?B2)
+    (and
+      (instance ?B1 Blade)
+      (instance ?B2 Blade)
+      (part ?B1 ?PS)
+      (part ?B2 ?PS)
+      (not (equal ?B1 ?B2)))))
+
+(=>
+  (instance ?PS PruningShears)
+  (exists (?SC)
+    (and
+      (instance ?SC Screw)
+      (part ?SC ?PS))))
+
+(=>
+  (instance ?PS PruningShears)
+  (hasPurpose ?PS
+    (exists (?SHR ?PLANT)
+      (and
+        (instance ?SHR Shearing)
+        (instrument ?SHR ?PS)
+        (instance ?PLANT PlantMatter)
+        (patient ?SHR ?PLANT)))))
+
+(capability Cutting instrument PruningShears)
+(capability Shearing instrument PruningShears)
 
 (subclass Fork Tableware)
+
 (termFormat EnglishLanguage Fork "fork")
 (documentation Fork EnglishLanguage "A &%Fork is a &%Tableware implement with a
-handle and multiple pointed &%Tines used to spear, hold, and lift food
-during eating.  Distinguished from a &%Spoon, which scoops food from
-below with a concave bowl: a &%Fork pierces food from above with its
-&%Tines.  Both are instruments of &%Eating but use different mechanisms
-of food transfer.")
+  &%Handle and pointed &%Tines used to spear, hold, and lift food
+  during eating.  Distinguished from a &%Spoon, which scoops food from
+  below with a concave &%Bowl: a &%Fork pierces food from above with its
+  &%Tines.  Both are instruments of &%Eating but use different mechanisms
+  of food transfer.")
 
 (=>
   (and
@@ -378,8 +491,6 @@ of food transfer.")
         (instance ?EAT Eating)
         (instrument ?EAT ?FK)))))
 
-;; connects Fork to the Tine term defined above
-
 (=>
   (instance ?F Fork)
   (exists (?T)
@@ -387,26 +498,31 @@ of food transfer.")
       (instance ?T Tine)
       (component ?T ?F))))
 
-(=> (instance ?F Fork) (exists (?H) (and (instance ?H Handle) (part ?H ?F))))
-
-(increasesLikelihood
+(=>
   (instance ?F Fork)
-  (or
-    (material Metal ?F)
-    (material Wood ?F)
-    (material Plastic ?F)))
+  (exists (?H)
+    (and
+      (instance ?H Handle)
+      (part ?H ?F))))
+
+(=>
+  (instance ?F Fork)
+  (modalAttribute
+    (or
+      (material Metal ?F)
+      (material Plastic ?F)) Likely))
 
 (capability Eating instrument Fork)
 
-
 (subclass Plate Tableware)
 (subclass Plate Dish)
+
 (termFormat EnglishLanguage Plate "plate")
 (documentation Plate EnglishLanguage "A flat or shallow &%Tableware dish
-used for serving or eating food.  &%Plates are characterized by a broad
-flat surface with a slightly raised rim, designed to present food for
-individual consumption.  Unlike a &%Bowl, which has a deep concave
-interior for holding liquids, a plate is predominantly flat.")
+  used for serving or eating food.  &%Plates are characterized by a broad
+  flat surface with a slightly raised rim, designed to present food for
+  individual consumption.  Unlike a &%Bowl, which has a deep concave
+  interior for holding liquids, a &%Plate is predominantly flat.")
 
 (=>
   (and
@@ -426,24 +542,28 @@ interior for holding liquids, a plate is predominantly flat.")
         (instance ?EAT Eating)
         (instrument ?EAT ?PL)))))
 
-(increasesLikelihood
+(=>
   (instance ?PL Plate)
-  (or
-    (material Glass ?PL)
-    (material Plastic ?PL)))
+  (modalAttribute
+    (or
+      (material Glass ?PL)
+      (material Ceramic ?PL)
+      (material Metal ?PL)) Likely))
 
-(=> (instance ?P Plate) (attribute ?P Flat))
+(=>
+  (instance ?P Plate)
+  (attribute ?P Flat))
 
 (capability Eating instrument Plate)
 
-
 (subclass DiningCup DrinkingCup)
+
 (termFormat EnglishLanguage DiningCup "cup")
 (documentation DiningCup EnglishLanguage "A &%DiningCup is a &%DrinkingCup, i.e. an
-open &%FluidContainer intended to serve a &%Beverage to a single
-person.  Distinguished from a &%DrinkingMug by not requiring a handle.
-Distinguished from a &%Bowl by its taller, narrower profile and
-primary use for beverages rather than food.")
+  open &%FluidContainer intended to serve a &%Beverage to a single person.
+  Distinguished from a &%DrinkingMug, which is a more robust vessel typically
+  with a &%Handle.  Distinguished from a &%Bowl by its taller, narrower profile
+  and primary use for beverages rather than food.")
 
 (=>
   (and
@@ -461,24 +581,25 @@ primary use for beverages rather than food.")
         (instance ?DRINK Drinking)
         (instrument ?DRINK ?CUP)))))
 
-(increasesLikelihood
+(=>
   (instance ?C DiningCup)
-  (or
-    (material Glass ?C)
-    (material Plastic ?C)
-    (material Metal ?C)))
+  (modalAttribute
+    (or
+      (material Glass ?C)
+      (material Ceramic ?C)
+      (material Plastic ?C)) Likely))
 
 (capability Drinking instrument DiningCup)
 
-
 (subclass Vase Container)
 (subclass Vase ArtWork)
+
 (termFormat EnglishLanguage Vase "vase")
 (documentation Vase EnglishLanguage "A &%Vase is a &%Container, typically tall and
-narrow, used to hold cut flowers or serve as an ornamental object.
-A &%Vase is distinguished from other containers by its decorative
-purpose and its characteristic tall, narrow profile with an
-opening at the top.")
+  narrow, used to hold cut flowers or serve as an ornamental object.
+  A &%Vase is distinguished from other containers by its decorative
+  purpose and its characteristic tall, narrow profile with an
+  opening at the top.")
 
 (=>
   (and
@@ -488,25 +609,35 @@ opening at the top.")
     (located ?V ?PLACE))
   (located ?OBJ ?PLACE))
 
-(increasesLikelihood
+(=>
   (instance ?V Vase)
-  (exists (?FLOWER)
-    (and
-      (instance ?FLOWER FloweringPlant)
-      (contains ?V ?FLOWER))))
+  (modalAttribute
+    (exists (?FLOWER)
+      (and
+        (instance ?FLOWER FloweringPlant)
+        (contains ?V ?FLOWER))) Likely))
 
-(increasesLikelihood
+(=>
   (instance ?V Vase)
-  (material Glass ?V))
+  (modalAttribute
+    (material Glass ?V) Likely))
 
+(=>
+  (instance ?V Vase)
+  (hasPurpose ?V
+    (exists (?FLOWER)
+      (and
+        (instance ?FLOWER FloweringPlant)
+        (contains ?V ?FLOWER)))))
 
 (subclass Bucket Container)
+
 (termFormat EnglishLanguage Bucket "bucket")
 (documentation Bucket EnglishLanguage "A &%Bucket is an open-topped cylindrical
-&%Container with a semicircular carrying handle, used for transporting
-liquids, sand, or other materials.  A &%Bucket is distinguished from a
-&%Bowl by its taller profile, carrying handle, and typical use in
-transporting rather than serving.")
+  &%Container with a semicircular carrying handle, used for transporting
+  liquids, sand, or other materials.  A &%Bucket is distinguished from a
+  &%Bowl by its taller profile, carrying handle, and typical use in
+  transporting rather than serving.")
 
 (=>
   (and
@@ -526,11 +657,12 @@ transporting rather than serving.")
         (instance ?MOVE Translocation)
         (instrument ?MOVE ?BK)))))
 
-(increasesLikelihood
+(=>
   (instance ?BK Bucket)
-  (or
-    (material Metal ?BK)
-    (material Plastic ?BK)))
+  (modalAttribute
+    (or
+      (material Metal ?BK)
+      (material Plastic ?BK)) Likely))
 
 (=>
   (instance ?BK Bucket)
@@ -541,14 +673,14 @@ transporting rather than serving.")
 
 (capability Translocation instrument Bucket)
 
-
 (subclass Backpack Container)
+
 (termFormat EnglishLanguage Backpack "backpack")
 (documentation Backpack EnglishLanguage "A &%Backpack is a &%Container designed to be
-carried on the back via shoulder straps.  A &%Backpack distributes the
-weight of its contents across the wearer's shoulders and back,
-allowing hands-free transport of belongings during walking, hiking,
-or commuting.")
+  carried on the back via shoulder straps.  A &%Backpack distributes the
+  weight of its contents across the wearer's shoulders and back,
+  allowing hands-free transport of belongings during walking, hiking,
+  or commuting.")
 
 (=>
   (and
@@ -566,20 +698,21 @@ or commuting.")
         (instance ?MOVE Translocation)
         (instrument ?MOVE ?BP)))))
 
-(increasesLikelihood
+(=>
   (instance ?BP Backpack)
-  (material Fabric ?BP))
+  (modalAttribute
+    (material Fabric ?BP) Likely))
 
 (capability Translocation instrument Backpack)
 
-
 (subclass Umbrella Device)
+
 (termFormat EnglishLanguage Umbrella "umbrella")
 (documentation Umbrella EnglishLanguage "An &%Umbrella is a &%Device consisting of a
-collapsible canopy supported by a central shaft and radiating ribs,
-used for protection from rain or sunlight.  An &%Umbrella is held by
-hand and positioned above the user to shield them from precipitation
-or solar radiation.")
+  collapsible canopy supported by a central shaft and radiating ribs,
+  used for protection from rain or sunlight.  An &%Umbrella is held by
+  hand and positioned above the user to shield them from precipitation
+  or solar radiation.")
 
 (=>
   (and
@@ -589,29 +722,31 @@ or solar radiation.")
     (instrument ?WALK ?UMB))
   (located ?UMB ?PERSON))
 
-;; purpose modeled as orientation (held above a person) rather than
-;; as instrument of a process, since an umbrella shields passively
-
 (=>
   (instance ?UMB Umbrella)
   (hasPurpose ?UMB
-    (exists (?PERSON)
+    (exists (?PROT ?PERSON)
       (and
+        (instance ?PROT Protecting)
         (instance ?PERSON Animal)
-        (orientation ?UMB ?PERSON Above)))))
+        (instrument ?PROT ?UMB)
+        (patient ?PROT ?PERSON)))))
 
-(increasesLikelihood
+(capability Protecting instrument Umbrella)
+
+(=>
   (instance ?UMB Umbrella)
-  (material Fabric ?UMB))
-
+  (modalAttribute
+    (material Fabric ?UMB) Likely))
 
 (subclass Shovel Device)
 (subclass Shovel HandTool)
+
 (termFormat EnglishLanguage Shovel "shovel")
 (documentation Shovel EnglishLanguage "A &%Shovel is a hand-operated &%Device with a
-broad flat or concave blade attached to a long handle, used for digging
-into and moving loose material such as soil, sand, snow, or gravel.
-Distinguished from a spade by its wider, more concave blade shape.")
+  broad flat or concave blade attached to a long handle, used for digging
+  into and moving loose material such as soil, sand, snow, or gravel.
+  Distinguished from a spade by its wider, more concave blade shape.")
 
 (=>
   (and
@@ -631,27 +766,35 @@ Distinguished from a spade by its wider, more concave blade shape.")
         (instance ?DIG Digging)
         (instrument ?DIG ?SH)))))
 
-(increasesLikelihood
+(=>
   (instance ?SH Shovel)
-  (and
-    (material Metal ?SH)
-    (material Wood ?SH)))
+  (modalAttribute
+    (and
+      (material Metal ?SH)
+      (material Wood ?SH)) Likely))
 
-(=> (instance ?SH Shovel) (attribute ?SH Rigid))
+(=>
+  (instance ?SH Shovel)
+  (attribute ?SH Rigid))
 
-(=> (instance ?SH Shovel) (exists (?H) (and (instance ?H Handle) (part ?H ?SH))))
+(=>
+  (instance ?SH Shovel)
+  (exists (?H)
+    (and
+      (instance ?H Handle)
+      (part ?H ?SH))))
 
 (capability Digging instrument Shovel)
 
-
 (subclass Pliers Device)
 (subclass Pliers HandTool)
+
 (termFormat EnglishLanguage Pliers "pliers")
 (documentation Pliers EnglishLanguage "&%Pliers are a hand-operated &%Device
-consisting of two hinged arms with flat or serrated jaws, used for
-gripping, bending, or cutting wire and other materials.  &%Pliers
-function by applying mechanical advantage through the pivot point
-to multiply the user's grip strength.")
+  consisting of two hinged arms with flat or serrated jaws, used for
+  gripping, bending, or cutting wire and other materials.  &%Pliers
+  function by applying mechanical advantage through the pivot point
+  to multiply the user's grip strength.")
 
 (=>
   (and
@@ -668,24 +811,32 @@ to multiply the user's grip strength.")
   (hasPurpose ?PL
     (exists (?PROC)
       (and
-        (instance ?PROC IntentionalProcess)
+        (or
+          (instance ?PROC Compressing)
+          (instance ?PROC Cutting))
         (instrument ?PROC ?PL)))))
 
-(increasesLikelihood
+(=>
   (instance ?PL Pliers)
-  (material Metal ?PL))
+  (modalAttribute
+    (material Metal ?PL) Likely))
 
-(=> (instance ?PL Pliers) (attribute ?PL Rigid))
+(=>
+  (instance ?PL Pliers)
+  (attribute ?PL Rigid))
 
+(capability Compressing instrument Pliers)
+(capability Cutting instrument Pliers)
 
 (subclass Rake Device)
 (subclass Rake HandTool)
+
 (termFormat EnglishLanguage Rake "rake")
 (documentation Rake EnglishLanguage "A &%Rake is a &%Device consisting of a long
-handle with a head of projecting tines or teeth, used for gathering
-leaves, grass clippings, hay, or other loose material, and for
-smoothing soil.  Distinguished from a &%Shovel, which scoops and
-lifts material, a &%Rake gathers by dragging across a surface.")
+  handle with a head of projecting tines or teeth, used for gathering
+  leaves, grass clippings, hay, or other loose material, and for
+  smoothing soil.  Distinguished from a &%Shovel, which scoops and
+  lifts material, a &%Rake gathers by dragging across a surface.")
 
 (=>
   (instance ?R Rake)
@@ -694,7 +845,12 @@ lifts material, a &%Rake gathers by dragging across a surface.")
       (instance ?T Tine)
       (component ?T ?R))))
 
-(=> (instance ?RK Rake) (exists (?H) (and (instance ?H Handle) (part ?H ?RK))))
+(=>
+  (instance ?RK Rake)
+  (exists (?H)
+    (and
+      (instance ?H Handle)
+      (part ?H ?RK))))
 
 (=>
   (instance ?R Rake)
@@ -706,8 +862,11 @@ lifts material, a &%Rake gathers by dragging across a surface.")
         (instance ?MAT Object)
         (patient ?MOVE ?MAT)))))
 
-(increasesLikelihood
+(=>
   (instance ?RK Rake)
-  (and
-    (material Metal ?RK)
-    (material Wood ?RK)))
+  (modalAttribute
+    (and
+      (material Metal ?RK)
+      (material Wood ?RK)) Likely))
+
+(capability Translocation instrument Rake)

--- a/Objects.kif
+++ b/Objects.kif
@@ -27,7 +27,6 @@
       (component ?T ?O))))
 
 (capability Poking instrument Tine)
-(capability Piercing instrument Tine)
 
 (=>
   (and


### PR DESCRIPTION
This is the second in a series of incremental improvements to Objects.kif.

**New term**

- `KitchenShears` — subclass of `Scissors` scoped to food preparation. Inherits the two-`Blade`/pivot-`Screw` structure of `Scissors`. Adds `hasPurpose` and `increasesLikelihood` rules constraining the patient to `Food`.

**Revised terms: Scissors, PruningShears**

- Documentation strings updated to reference `&%Blade` and `&%Screw` formally.
- New rules asserting two distinct `Blade` parts (`not (equal ?B1 ?B2)`) and one `Screw` part (the pivot), backing the structural claims in the documentation.

**Revised terms: Fork, Plate, DiningCup**

- Full `&%` scrub on all documentation strings: every SUMO class or relation reference now carries its `&%` hyperlink prefix.
- Removed a misuse of `&%Spear` as a verb in the Fork documentation (was incorrectly linking to the weapon class `Spear`).
- Fixed `DrinkingMug` distinction in `DiningCup` to avoid an unaxiomatizable negative claim ("not requiring a Handle") — rephrased as a positive description of `DrinkingMug`.

**Formatting**

- Blank line between every top-level rule and axiom throughout the Scissors–DiningCup section, consistent with the convention already present in lines 1–299.

Preceded by PR #550 (Tine through Shearing). Next PR will cover Vase through Rake.