### PR TITLE
Fixed Test Failure By Removing Extraneous Parenthesis

### DIFF
--- a/tests/TPTP/feener_CHAD_examples/Obligation_KIF.kif
+++ b/tests/TPTP/feener_CHAD_examples/Obligation_KIF.kif
@@ -91,7 +91,7 @@
    (exists (?TAX)
      (and 
        (instance ?TAX Tax)
-       (origin ?TAX Bill))) Obligation))  
+       (origin ?TAX Bill))) Obligation)
 ;thf(conjecture_he_get_taxed, conjecture, (
 ;  ?[Wx: w] : (
 ;    (accreln1 @ s__Obligation @ cw @ Wx) &


### PR DESCRIPTION
Removed an extraneous parenthesis from tests/TPTP/feener_CHAD_examples/Obligation_KIF.kif