### PR TITLE
Improve Objects.kif: Pliers and Rake; add RakeTooth

### DIFF
--- a/Objects.kif
+++ b/Objects.kif
@@ -18,7 +18,7 @@
   (instance ?T Tine)
   (modalAttribute
     (attribute ?T LongAndThin) Likely))
-    
+
 (=>
   (instance ?T Tine)
   (exists (?O)
@@ -27,6 +27,27 @@
       (component ?T ?O))))
 
 (capability Poking instrument Tine)
+
+(subclass RakeTooth EngineeringComponent)
+(termFormat EnglishLanguage RakeTooth "rake tooth")
+(documentation RakeTooth EnglishLanguage "A &%RakeTooth is an &%EngineeringComponent
+  that engages loose surface material when its parent &%Rake is moved across a
+  surface.  &%RakeTeeth project in parallel from the rake's working end; several
+  contribute to a &%Rake, with count and form varying by rake type (typically
+  three or more rigid metal teeth on a garden rake; six or more thinner, often
+  flexible teeth on a leaf rake).  &%RakeTeeth are typically curved at the
+  working end, which distinguishes their functional behavior from the straight
+  projections of a &%Tine on a &%Fork: the curve enables a &%RakeTooth to drag
+  and gather material across a surface, whereas a straight &%Tine would tend
+  to penetrate the material on contact.")
+
+(typicalPart RakeTooth Rake)
+(typicallyContainsPart RakeTooth Rake)
+
+(=>
+  (instance ?RT RakeTooth)
+  (modalAttribute
+    (attribute ?RT Concave) Likely))
 
 (=>
   (and
@@ -94,7 +115,7 @@
 (=>
   (instance ?B Bowl)
   (modalAttribute
-    (instance ?B PorousContainer) Unlikely))
+    (PorousContainer ?B) Unlikely))
 
 (=>
   (instance ?B Bowl)
@@ -228,7 +249,7 @@
       (instance ?FOOD Food)
       (patient ?MOVE ?FOOD)
       (patient ?EAT ?FOOD))))
-      
+
 (=>
   (instance ?SP Spoon)
   (modalAttribute
@@ -294,8 +315,8 @@
   (greaterThan
     (MohsScaleFn ?IMAT)
     (MohsScaleFn ?PMAT)))
-    
 
+(subclass Scissors CuttingDevice)
 (subclass Scissors HandTool)
 
 (termFormat EnglishLanguage Scissors "scissors")
@@ -303,7 +324,7 @@
   of two &%Blade components joined at a pivot &%Screw and operated by a &%Handle on
   each blade, so that opening and closing the handles drives the blades
   across each other to cut material. Unlike a &%Knife, which cuts by
-  drawing a single blade across a surface, &%Scissors cut by the &%Shearing
+  drawing a single blade across a surface, scissors cut by the shearing
   action of two opposing blades. &%Scissors are used to cut paper,
   fabric, hair, and other thin materials.")
 
@@ -377,10 +398,10 @@
 
 (termFormat EnglishLanguage KitchenShears "kitchen shears")
 (documentation KitchenShears EnglishLanguage "&%KitchenShears are &%Scissors
-  designed for food preparation, used to cut &%Food items such as poultry
-  and herbs.  &%KitchenShears inherit the two-&%Blade pivot-&%Screw structure
-  of &%Scissors but are heavier and more durable, suited for cutting dense
-  or moist food material.")
+  designed for &%Food preparation, used to cut &%Food such as poultry, herbs,
+  and packaging in a &%Cooking context.  &%KitchenShears inherit the two-&%Blade
+  pivot-&%Screw structure of &%Scissors but are heavier and more durable,
+  suited for cutting dense or moist food material.")
 
 (=>
   (instance ?KS KitchenShears)
@@ -414,7 +435,7 @@
   branches, and other botanical material by &%Shearing action.  Like &%Scissors,
   &%PruningShears cut by the coordinated action of two opposing blades; unlike
   &%Scissors, they are sized and hardened for cutting live or woody &%Plant tissue.
-  The typical patient of a &%PruningShears operation is &%PlantMatter.")
+  The typical &%Patient of a &%PruningShears operation is &%PlantMatter.")
 
 (=>
   (instance ?PS PruningShears)
@@ -466,9 +487,9 @@
 
 (termFormat EnglishLanguage Fork "fork")
 (documentation Fork EnglishLanguage "A &%Fork is a &%Tableware implement with a
-  &%Handle and pointed &%Tines used to spear, hold, and lift food
+  &%Handle and multiple pointed &%Tines used to &%Spear, hold, and lift &%Food
   during eating.  Distinguished from a &%Spoon, which scoops food from
-  below with a concave &%Bowl: a &%Fork pierces food from above with its
+  below with a concave bowl: a &%Fork pierces food from above with its
   &%Tines.  Both are instruments of &%Eating but use different mechanisms
   of food transfer.")
 
@@ -521,7 +542,7 @@
   used for serving or eating food.  &%Plates are characterized by a broad
   flat surface with a slightly raised rim, designed to present food for
   individual consumption.  Unlike a &%Bowl, which has a deep concave
-  interior for holding liquids, a &%Plate is predominantly flat.")
+  interior for holding liquids, a plate is predominantly flat.")
 
 (=>
   (and
@@ -559,10 +580,10 @@
 
 (termFormat EnglishLanguage DiningCup "cup")
 (documentation DiningCup EnglishLanguage "A &%DiningCup is a &%DrinkingCup, i.e. an
-  open &%FluidContainer intended to serve a &%Beverage to a single person.
-  Distinguished from a &%DrinkingMug, which is a more robust vessel typically
-  with a &%Handle.  Distinguished from a &%Bowl by its taller, narrower profile
-  and primary use for beverages rather than food.")
+  open &%FluidContainer intended to serve a &%Beverage to a single
+  person.  Distinguished from a &%DrinkingMug by not requiring a handle.
+  Distinguished from a &%Bowl by its taller, narrower profile and
+  primary use for beverages rather than food.")
 
 (=>
   (and
@@ -892,12 +913,21 @@
 
 (=>
   (instance ?PL Pliers)
+  (exists (?H)
+    (and
+      (instance ?H Hinge)
+      (component ?H ?PL))))
+
+(=>
+  (instance ?PL Pliers)
   (hasPurpose ?PL
     (exists (?PROC)
       (and
         (or
           (instance ?PROC Compressing)
-          (instance ?PROC Cutting))
+          (instance ?PROC Cutting)
+          (instance ?PROC Keeping)
+          (instance ?PROC Bending))
         (instrument ?PROC ?PL)))))
 
 (=>
@@ -911,6 +941,8 @@
 
 (capability Compressing instrument Pliers)
 (capability Cutting instrument Pliers)
+(capability Keeping instrument Pliers)
+(capability Bending instrument Pliers)
 
 (subclass Rake Device)
 (subclass Rake HandTool)
@@ -924,10 +956,12 @@
 
 (=>
   (instance ?R Rake)
-  (exists (?T)
+  (exists (?P)
     (and
-      (instance ?T Tine)
-      (component ?T ?R))))
+      (or
+        (instance ?P Tine)
+        (instance ?P RakeTooth))
+      (component ?P ?R))))
 
 (=>
   (instance ?RK Rake)
@@ -948,9 +982,32 @@
 
 (=>
   (instance ?RK Rake)
+  (hasPurpose ?RK
+    (exists (?SM ?S)
+      (and
+        (instance ?SM Smoothing)
+        (instance ?S Soil)
+        (instrument ?SM ?RK)
+        (patient ?SM ?S)))))
+
+(=>
+  (instance ?RK Rake)
+  (hasPurpose ?RK
+    (exists (?MOVE)
+      (and
+        (or
+          (instance ?MOVE Pulling)
+          (instance ?MOVE Pushing))
+        (instrument ?MOVE ?RK)))))
+
+(=>
+  (instance ?RK Rake)
   (modalAttribute
-    (and
+    (or
       (material Metal ?RK)
       (material Wood ?RK)) Likely))
 
 (capability Translocation instrument Rake)
+(capability Smoothing instrument Rake)
+(capability Pulling instrument Rake)
+(capability Pushing instrument Rake)


### PR DESCRIPTION
Axiomatizes Pliers and Rake in Objects.kif and adds RakeTooth as a new structural component term.

Terms (Objects.kif):

- Pliers: required Hinge component; hasPurpose disjunction broadened from Compressing or Cutting to Compressing, Cutting, Keeping, or Bending; capability statements added for Keeping and Bending. Keeping covers the gripping-and-holding sense (parallels the Reel pattern in Cars.kif: a Device that is the instrument of a Keeping process whose patient is the held object).
- Rake: structural projection rule weakened from Tine-only to Tine or RakeTooth; new hasPurpose for Smoothing of Soil; new hasPurpose for Pulling or Pushing as the motion mechanism; capability statements added for Smoothing, Pulling, and Pushing. Material rule corrected from conjunctive Metal-and-Wood to disjunctive Metal-or-Wood (the conjunctive form had asserted every rake is simultaneously both materials).

New structural term (Objects.kif):

- RakeTooth: subclass EngineeringComponent. Distinct from anatomical Tooth (subclass Bone) and from Tine, which is essentially Rigid and affords penetration. RakeTooth typically Concave at the working end, contrasting with the Convex straight projection of a ForkTine: the curve enables dragging and gathering across a surface where a straight tine would tend to penetrate. typicalPart and typicallyContainsPart relations to Rake (parallels GunTrigger / GunStock pattern in Mid-level-ontology.kif).

Validation:

Objects.kif paren balance 847/847. KifFileChecker on the changed file exits clean with no orphan-variable or null-signature flags attributable to this batch.