### PR TITLE
Add ToolJaw and RakeHead; refactor Rake materials per-part

### DIFF
--- a/Mid-level-ontology.kif
+++ b/Mid-level-ontology.kif
@@ -1632,6 +1632,43 @@ the &%Gun.")
 (typicalPart GunTrigger Gun)
 (typicallyContainsPart GunTrigger Gun)
 
+(subclass ToolJaw EngineeringComponent)
+(termFormat EnglishLanguage ToolJaw "tool jaw")
+(documentation ToolJaw EnglishLanguage "A &%ToolJaw is one of two opposed gripping
+  surfaces on a clamping or holding hand-operated &%Device such as &%Pliers, a wrench,
+  or a vise.  Opposed &%ToolJaws close against one another through the host tool's
+  &%Hinge or screw mechanism to apply force to a held &%Object.  A &%ToolJaw is a
+  manufactured &%EngineeringComponent and is distinct from the anatomical &%Jaw of
+  an &%Animal.")
+
+(=>
+  (instance ?J1 ToolJaw)
+  (exists (?J2 ?T)
+    (and
+      (instance ?J2 ToolJaw)
+      (not
+        (equal ?J1 ?J2))
+      (instance ?T Device)
+      (component ?J1 ?T)
+      (component ?J2 ?T))))
+
+(=>
+  (and
+    (instance ?J ToolJaw)
+    (instance ?T Device)
+    (component ?J ?T))
+  (hasPurpose ?J
+    (exists (?GRIP ?O)
+      (and
+        (or
+          (instance ?GRIP Keeping)
+          (instance ?GRIP Pulling))
+        (instrument ?GRIP ?T)
+        (patient ?GRIP ?O)))))
+
+(typicalPart ToolJaw Pliers)
+(typicallyContainsPart ToolJaw Pliers)
+
 (subclass LoadingWeapon Inserting)
 (documentation LoadingWeapon EnglishLanguage "Inserting ammunition into a &%ProjectileWeapon
 in such a way that the ammunition can be fired by the weapon.")

--- a/Objects.kif
+++ b/Objects.kif
@@ -43,11 +43,17 @@
 
 (typicalPart RakeTooth Rake)
 (typicallyContainsPart RakeTooth Rake)
+(typicalPart RakeTooth RakeHead)
 
 (=>
   (instance ?RT RakeTooth)
   (modalAttribute
     (attribute ?RT Concave) Likely))
+
+(=>
+  (instance ?RT RakeTooth)
+  (modalAttribute
+    (material Metal ?RT) Likely))
 
 (=>
   (and
@@ -73,6 +79,29 @@
       (component ?T2 ?O)
       (not
         (equal ?T1 ?T2)))))
+
+(subclass RakeHead EngineeringComponent)
+(termFormat EnglishLanguage RakeHead "rake head")
+(documentation RakeHead EnglishLanguage "A &%RakeHead is an &%EngineeringComponent
+  that forms the working end of a &%Rake.  &%RakeTooth components project in
+  parallel from the &%RakeHead, and the &%RakeHead in turn attaches to the rake's
+  &%Handle.  When a &%Rake is drawn across a surface, the &%RakeHead transfers
+  force from the handle to the teeth and so to the surface material being raked.")
+
+(typicalPart RakeHead Rake)
+(typicallyContainsPart RakeHead Rake)
+
+(=>
+  (instance ?H RakeHead)
+  (exists (?T)
+    (and
+      (instance ?T RakeTooth)
+      (part ?T ?H))))
+
+(=>
+  (instance ?H RakeHead)
+  (modalAttribute
+    (material Metal ?H) Likely))
 
 (subclass Bowl Container)
 (subclass Bowl Dish)
@@ -1002,10 +1031,18 @@
 
 (=>
   (instance ?RK Rake)
+  (exists (?H)
+    (and
+      (instance ?H RakeHead)
+      (part ?H ?RK))))
+
+(=>
+  (and
+    (instance ?RK Rake)
+    (instance ?H Handle)
+    (part ?H ?RK))
   (modalAttribute
-    (or
-      (material Metal ?RK)
-      (material Wood ?RK)) Likely))
+    (material Wood ?H) Likely))
 
 (capability Translocation instrument Rake)
 (capability Smoothing instrument Rake)


### PR DESCRIPTION
Adds two new structural component terms and refactors the Rake material rule into per-part claims. Continuation of the Vase through Rake working set in Objects.kif (PRs #550, #556, #558).

New structural term (Mid-level-ontology.kif):

- ToolJaw: subclass EngineeringComponent. Sibling of the anatomical Jaw (Anatomy.kif:1680, subclass BodyPart), introduced to give Pliers, wrenches, vises, and similar clamping or holding hand tools a non-anatomical jaw component to attach to. An opposed-pair axiom asserts that every ToolJaw is accompanied by a second ToolJaw on the same host Device. A hasPurpose axiom binds ToolJaw to Keeping or Pulling relative to the held Object, matching the Keeping/Pulling sense already in the Pliers hasPurpose disjunction. typicalPart and typicallyContainsPart relate ToolJaw to Pliers (parallels the GunTrigger / Gun pattern). Wrench and a future Vise are named in the documentation as motivating cases; their own component wiring is deferred to a follow-on PR.

New structural term (Objects.kif):

- RakeHead: subclass EngineeringComponent. The working end of a Rake to which RakeTooth components attach, and which in turn attaches to the rake's Handle. Existence axiom requires every RakeHead to carry at least one RakeTooth. Material rule asserts Metal Likely. typicalPart and typicallyContainsPart relate RakeHead to Rake. Parallels the queued ShovelHead from the Shovel anatomy follow-on.

Refactor (Objects.kif, Rake):

- The rake-level disjunctive material rule from PR #558 (or (material Metal) (material Wood)) Likely is removed. Materials are now per-part: any Handle that is part of a Rake is Wood Likely; RakeTooth is Metal Likely (added to the RakeTooth block); RakeHead is Metal Likely. A new existence axiom requires every Rake to have a RakeHead part, so the structural enrichment formally bites. RakeTooth additionally gains a typicalPart relation to RakeHead alongside its existing typicalPart to Rake.

Validation:

Objects.kif paren balance 876 / 876. Mid-level-ontology.kif additions balanced at 30 open / 30 close; the file's pre-existing one-paren imbalance at HEAD is upstream of this change. KifFileChecker on the changed files exits clean with no orphan-variable or null-signature flags attributable to this batch.