### PR TITLE
Add GardeningRake, LawnRake, ZenGardenRake; Tine Convex axiom

### DIFF
--- a/Objects.kif
+++ b/Objects.kif
@@ -21,6 +21,11 @@
 
 (=>
   (instance ?T Tine)
+  (modalAttribute
+    (attribute ?T Convex) Likely))
+
+(=>
+  (instance ?T Tine)
   (exists (?O)
     (and
       (instance ?O CorpuscularObject)
@@ -132,6 +137,84 @@
   (instance ?H ShovelHead)
   (modalAttribute
     (attribute ?H Concave) Likely))
+
+(subclass GardeningRake Rake)
+(termFormat EnglishLanguage GardeningRake "gardening rake")
+(documentation GardeningRake EnglishLanguage "A &%GardeningRake is a &%Rake whose
+  &%RakeTooth components are rigid and typically &%Metal, suited for working &%Soil:
+  breaking up clods, levelling beds, gathering stones, and pulling out shallow
+  roots.  Distinguished from a &%LawnRake, whose teeth are not rigid and engage
+  loose plant matter rather than soil.")
+
+(=>
+  (and
+    (instance ?R GardeningRake)
+    (instance ?T RakeTooth)
+    (component ?T ?R))
+  (attribute ?T Rigid))
+
+(=>
+  (and
+    (instance ?R GardeningRake)
+    (instance ?T RakeTooth)
+    (component ?T ?R))
+  (modalAttribute
+    (material Metal ?T) Likely))
+
+(=>
+  (instance ?R GardeningRake)
+  (hasPurpose ?R
+    (exists (?SC ?S)
+      (and
+        (instance ?SC SurfaceChange)
+        (instance ?S Soil)
+        (instrument ?SC ?R)
+        (patient ?SC ?S)))))
+
+(subclass LawnRake Rake)
+(termFormat EnglishLanguage LawnRake "lawn rake")
+(documentation LawnRake EnglishLanguage "A &%LawnRake (also called a leaf rake) is a
+  &%Rake whose &%RakeTooth components are not rigid: they flex on contact with the
+  surface, which allows them to sweep loose plant matter such as fallen leaves and
+  grass clippings without digging into the underlying ground.  Distinguished from a
+  &%GardeningRake, whose rigid metal teeth engage soil rather than loose surface
+  material.")
+
+(=>
+  (and
+    (instance ?R LawnRake)
+    (instance ?T RakeTooth)
+    (component ?T ?R))
+  (not
+    (attribute ?T Rigid)))
+
+(=>
+  (instance ?R LawnRake)
+  (hasPurpose ?R
+    (exists (?TR ?P)
+      (and
+        (instance ?TR Translocation)
+        (instance ?P PlantAnatomicalStructure)
+        (instrument ?TR ?R)
+        (patient ?TR ?P)))))
+
+(subclass ZenGardenRake Rake)
+(termFormat EnglishLanguage ZenGardenRake "zen garden rake")
+(documentation ZenGardenRake EnglishLanguage "A &%ZenGardenRake is a &%Rake with a
+  small number of widely-spaced &%RakeTooth components, used to draw parallel
+  furrows in loose &%Soil for &%Smoothing into a patterned surface rather than for
+  gathering loose material or working the underlying ground.  Typically held and
+  drawn by a &%Human across the surface in a single sustained pass.")
+
+(=>
+  (instance ?R ZenGardenRake)
+  (hasPurposeForAgent ?R Human
+    (exists (?SM ?S)
+      (and
+        (instance ?SM Smoothing)
+        (instance ?S Soil)
+        (instrument ?SM ?R)
+        (patient ?SM ?S)))))
 
 (subclass Bowl Container)
 (subclass Bowl Dish)


### PR DESCRIPTION
Adds three subclasses of Rake and a symmetric shape axiom for Tine. The parent Rake term in Objects.kif is intentionally underspecified at the rigidity, material, and tooth-form axes because rake subtypes diverge sharply on those axes; this PR adds the three commonly distinguished variants and binds each to the axes on which it actually differs from its siblings.

Terms (Objects.kif):

- GardeningRake: a Rake whose RakeTooth components are Rigid and typically Metal Likely, suited for working Soil. A hasPurpose axiom binds the rake to a SurfaceChange whose patient is Soil, which captures the breaking-up, levelling, and shallow-root-pulling sense distinct from the leaf-rake use.
- LawnRake (also called a leaf rake): a Rake whose RakeTooth components are not Rigid; their flex on contact is what allows them to sweep loose plant matter without digging into the underlying ground. A hasPurpose axiom binds the rake to a Translocation whose patient is a PlantAnatomicalStructure, which covers fallen leaves and grass clippings.
- ZenGardenRake: a Rake used to draw parallel furrows in loose Soil for Smoothing into a patterned surface rather than for gathering loose material or working the ground. The cultural use is captured by hasPurposeForAgent Human binding the rake to a Smoothing of Soil; the parent Rake purpose of Pulling or Pushing still applies as an inherited motion mechanism.

Symmetric shape axiom (Objects.kif, Tine):

- (=> (instance ?T Tine) (modalAttribute (attribute ?T Convex) Likely))
- Mirrors the Concave Likely modal on RakeTooth from PR #558 and gives a Tine and a RakeTooth opposed default shape attributes. This is the prerequisite for a downstream tool-selection proof to derive that a RakeTooth gathers loose surface material whereas a straight Tine would tend to penetrate it.

Out of scope, queued for follow-on:

- GatheringLeaves and TillingSoil as new Process subtypes.
- The full Robot Landscaper tool-selection proof scenario in ProofScenarios.kif. That PR uses the three subclasses added here together with the new Process subtypes to discharge a Vampire proof that the appropriate instrument for each task can be selected from tool anatomy and process patient class rather than from explicit programming.

Validation: Objects.kif paren balance 911 / 911. KifFileChecker on the changed file exits clean with no orphan-variable or null-signature flags attributable to this batch.