### PR TITLE
Pliers and Shovel lever-physics axioms

### DIFF
--- a/Objects.kif
+++ b/Objects.kif
@@ -909,6 +909,19 @@
 
 (=>
   (and
+    (instance ?SH Shovel)
+    (instance ?DIG Digging)
+    (instrument ?DIG ?SH))
+  (exists (?ROT ?H)
+    (and
+      (instance ?ROT Rotating)
+      (subProcess ?ROT ?DIG)
+      (instance ?H Handle)
+      (part ?H ?SH)
+      (lever ?ROT ?H))))
+
+(=>
+  (and
     (instance ?DIG Digging)
     (instrument ?DIG ?I)
     (patient ?DIG ?P)
@@ -967,6 +980,20 @@
 (=>
   (instance ?PL Pliers)
   (attribute ?PL Rigid))
+
+(=>
+  (and
+    (instance ?PL Pliers)
+    (instance ?PROC IntentionalProcess)
+    (instrument ?PROC ?PL))
+  (exists (?ROT ?H)
+    (and
+      (instance ?ROT Rotating)
+      (subProcess ?ROT ?PROC)
+      (instance ?H Hinge)
+      (component ?H ?PL)
+      (fulcrum ?ROT ?H)
+      (lever ?ROT ?PL))))
 
 (capability Compressing instrument Pliers)
 (capability Cutting instrument Pliers)


### PR DESCRIPTION
Backs the mechanical-advantage claim in the Pliers documentation and extends Shovel with the same lever-physics vocabulary, reusing SUMO's existing fulcrum / lever / Rotating case roles rather than introducing new mechanics terms.

Pliers (Objects.kif):

- When Pliers are the instrument of any IntentionalProcess, a Rotating sub-event exists in which the Pliers' Hinge is the fulcrum and the Pliers themselves are the lever. The Hinge-as-component requirement was already in place from PR #558; this PR binds it to the Rotating case roles that the Pliers doc string asserts. The relevant sentence in the existing documentation is "function by applying mechanical advantage through the pivot point to multiply the user's grip strength," which was previously a free-floating claim and is now grounded in fulcrum and lever for any downstream proof that needs to derive mechanical-advantage behavior from Pliers being the instrument of a process.

Shovel (Objects.kif):

- When a Shovel is the instrument of a Digging, a Rotating sub-event exists in which the Shovel's Handle is the lever. The Handle-as-part requirement was already in place from PR #556; this PR binds it to the Rotating case role.

Out of scope for this PR, queued for the Backpack-ergonomics follow-on:

- The fulcrum on a Shovel is the user's lower grip point along the shaft, which is not yet a named term in SUMO. Naming the fulcrum cleanly requires the same kind of body-grip-region term (something like UpperBack, LumbarRegion, or a generic GripPoint) that the queued Backpack ergonomics PR needs anyway. Bundling those together keeps the human-body axioms in one place rather than scattered across hand-tool PRs.
- ShovelHead per the queued Tool Anatomy section, which will let the Shovel's Rotating event also have a load case role pointing at the blade end.

Validation: Objects.kif paren balance 903 / 903. KifFileChecker on the changed file exits clean.