### PR TITLE
Backpack ergonomics and Shovel fulcrum

### DIFF
--- a/Medicine.kif
+++ b/Medicine.kif
@@ -5690,6 +5690,54 @@ below 97 &%FahrenheitDegrees.")
       (part ?T ?P)
       (equal ?B (BackFn ?T)))))
 
+(subclass UpperBack HumanBack)
+(termFormat EnglishLanguage UpperBack "upper back")
+(documentation UpperBack EnglishLanguage "The superior portion of the
+&%HumanBack at the level of the shoulder blades.  The &%UpperBack is the
+load-bearing region of a properly-fitted &%Backpack carried high on the
+torso, where the axial spine and the shoulder girdle together transfer the
+load through the skeletal column rather than through the lower-back
+musculature.")
+
+(=>
+  (instance ?U UpperBack)
+  (exists (?B ?P)
+    (and
+      (instance ?B HumanBack)
+      (instance ?P Human)
+      (part ?U ?B)
+      (part ?B ?P))))
+
+(subclass LumbarRegion HumanBack)
+(termFormat EnglishLanguage LumbarRegion "lumbar region")
+(documentation LumbarRegion EnglishLanguage "The inferior portion of the
+&%HumanBack at the level of the lumbar vertebrae.  The &%LumbarRegion is
+the load-bearing region of a &%Backpack carried low on the torso or with
+loosened straps; prolonged loading of this region rather than the
+&%UpperBack is associated with elevated risk of soft-tissue and disc
+injury.")
+
+(=>
+  (instance ?L LumbarRegion)
+  (exists (?B ?P)
+    (and
+      (instance ?B HumanBack)
+      (instance ?P Human)
+      (part ?L ?B)
+      (part ?B ?P))))
+
+(instance loadBearingRegion BinaryPredicate)
+(domain loadBearingRegion 1 Physical)
+(domain loadBearingRegion 2 BodyPart)
+(documentation loadBearingRegion EnglishLanguage "(&%loadBearingRegion ?L ?R)
+means that the force vector of the &%Physical load ?L projects principally
+onto the &%BodyPart ?R.  Distinct from &%connected, which expresses
+mereotopological adjacency without directional force, and from &%located,
+which expresses full spatial containment.  A worn &%Backpack carried high
+on the torso has its load-bearing region in the &%UpperBack; the same
+&%Backpack carried low or with loosened straps shifts its load-bearing
+region to the &%LumbarRegion.")
+
 (subclass MucusMembrane CellMembrane)
 (secretesSubstance MucusMembrane Mucus)
 

--- a/Objects.kif
+++ b/Objects.kif
@@ -787,6 +787,33 @@
   (modalAttribute
     (material Fabric ?BP) Likely))
 
+(=>
+  (and
+    (instance ?BP Backpack)
+    (instance ?MOVE Translocation)
+    (agent ?MOVE ?PERSON)
+    (instance ?PERSON Human)
+    (instrument ?MOVE ?BP))
+  (exists (?R)
+    (and
+      (or
+        (instance ?R UpperBack)
+        (instance ?R LumbarRegion))
+      (part ?R ?PERSON)
+      (loadBearingRegion ?BP ?R))))
+
+(=>
+  (and
+    (instance ?BP Backpack)
+    (instance ?L LumbarRegion)
+    (instance ?PERSON Human)
+    (part ?L ?PERSON)
+    (holdsDuring ?T
+      (loadBearingRegion ?BP ?L)))
+  (holdsDuring ?T
+    (not
+      (attribute ?PERSON Healthy))))
+
 (capability Translocation instrument Backpack)
 
 (subclass Umbrella Device)
@@ -919,6 +946,25 @@
       (instance ?H Handle)
       (part ?H ?SH)
       (lever ?ROT ?H))))
+
+(=>
+  (and
+    (instance ?SH Shovel)
+    (instance ?DIG Digging)
+    (instrument ?DIG ?SH)
+    (agent ?DIG ?PERSON)
+    (instance ?PERSON Human)
+    (instance ?ROT Rotating)
+    (subProcess ?ROT ?DIG)
+    (instance ?H Handle)
+    (part ?H ?SH)
+    (lever ?ROT ?H))
+  (exists (?HAND)
+    (and
+      (instance ?HAND Hand)
+      (part ?HAND ?PERSON)
+      (grasps ?PERSON ?H)
+      (fulcrum ?ROT ?HAND))))
 
 (=>
   (and


### PR DESCRIPTION
Closes the lever-physics arc that PR #561 deferred and adds the body-region terms needed to give Backpack a load-bearing-region axiomatization. New material lives in Medicine.kif (three terms) and Objects.kif (three rules across Backpack and Shovel).

New terms (Medicine.kif):

- UpperBack: subclass of HumanBack, the superior portion at the level of the shoulder blades. The canonical load-bearing region of a properly-fitted Backpack carried high on the torso, where the load transfers through the skeletal column rather than through the lower-back musculature.
- LumbarRegion: subclass of HumanBack, the inferior portion at the level of the lumbar vertebrae. The load-bearing region of a Backpack carried low or with loosened straps; prolonged loading of this region rather than the UpperBack is associated with soft-tissue and disc injury.
- loadBearingRegion: BinaryPredicate from Physical to BodyPart. Captures the directional force-vector projection of a load onto a body region. Distinct from connected (mereotopological adjacency, non-directional) and located (full spatial containment).

New axioms (Objects.kif, Backpack):

- When Backpack is the instrument of a Translocation whose agent is a Human, the wearer has a body region in {UpperBack, LumbarRegion} that is the loadBearingRegion of the Backpack. The disjunction reflects that strap state determines which region bears the load; the strap-state attributes themselves are deferred to a follow-on PR rather than introduced here as new attribute classes in Mid-level-ontology.kif.
- Health bridge: when loadBearingRegion holds between a Backpack and a wearer's LumbarRegion during a TimeInterval, the wearer is not Healthy during that TimeInterval. Uses the holdsDuring negation pattern from Medicine.kif:357. This is the load-bearing consequence rule that makes the UpperBack vs LumbarRegion distinction inferentially load-bearing for downstream proofs in ProofScenarios.kif.

New axiom (Objects.kif, Shovel):

- During a Digging in which the Shovel is the instrument and a Human is the agent, the user's Hand grasping the Handle is the fulcrum of the Rotating sub-event whose lever is the Handle (per the PR #561 Handle-as-lever rule). Closes the fulcrum case-role that PR #561 explicitly deferred to this PR. Reuses the existing Hand class (Mid-level-ontology.kif:14121) and grasps predicate (Merge.kif:11775); no new prerequisites are introduced.

Out of scope, queued for follow-on:

- Adjustable InternalAttribute and the Tight / Loose attribute values that would let the strap state be a first-class antecedent of the UpperBack-vs-LumbarRegion disjunction. The current rule preserves both possibilities behind an existential; the follow-on PR will add the deterministic strap-state mapping.
- A Backpack-as-lever framing with Rotating sub-events. SUMO's lever case role takes Rotating as its first argument and a worn backpack on a standing wearer is static, so binding lever to the wearer's torso would mis-use the case role. The load-bearing framing in this PR avoids that modelling mistake while still producing the Health bridge proof.

Validation: Medicine.kif paren balance 4534 / 4534. Objects.kif paren balance 948 / 948. KifFileChecker on both changed files exits clean with no orphan-variable or null-signature flags attributable to this batch.