### PR TITLE
Add ShovelHead; weaken Shovel Handle and Hand-fulcrum typicality

### DIFF
--- a/Objects.kif
+++ b/Objects.kif
@@ -103,6 +103,36 @@
   (modalAttribute
     (material Metal ?H) Likely))
 
+(subclass ShovelHead EngineeringComponent)
+(termFormat EnglishLanguage ShovelHead "shovel head")
+(documentation ShovelHead EnglishLanguage "A &%ShovelHead is an
+  &%EngineeringComponent that forms the working end of a &%Shovel: the
+  broad rigid blade that engages the loose material being dug.  A
+  &%ShovelHead is the essential digging component of a &%Shovel; an
+  autonomous agent can perform a &%Digging with a &%ShovelHead alone, as
+  when a small child uses a bare blade at the beach.  A &%Handle is a
+  typically-present leverage-enhancer rather than a structural
+  requirement: when a &%Handle is attached, the joint where the &%Handle
+  meets the &%ShovelHead can serve as the &%fulcrum of the &%Rotating
+  sub-event during a &%Digging into difficult ground.")
+
+(typicalPart ShovelHead Shovel)
+(typicallyContainsPart ShovelHead Shovel)
+
+(=>
+  (instance ?H ShovelHead)
+  (attribute ?H Rigid))
+
+(=>
+  (instance ?H ShovelHead)
+  (modalAttribute
+    (material Metal ?H) Likely))
+
+(=>
+  (instance ?H ShovelHead)
+  (modalAttribute
+    (attribute ?H Concave) Likely))
+
 (subclass Bowl Container)
 (subclass Bowl Dish)
 
@@ -918,21 +948,30 @@
 
 (=>
   (instance ?SH Shovel)
-  (modalAttribute
-    (or
-      (material Metal ?SH)
-      (material Wood ?SH)) Likely))
-
-(=>
-  (instance ?SH Shovel)
   (attribute ?SH Rigid))
 
 (=>
   (instance ?SH Shovel)
-  (exists (?H)
+  (exists (?HEAD)
     (and
-      (instance ?H Handle)
-      (part ?H ?SH))))
+      (instance ?HEAD ShovelHead)
+      (part ?HEAD ?SH))))
+
+(=>
+  (instance ?SH Shovel)
+  (modalAttribute
+    (exists (?H)
+      (and
+        (instance ?H Handle)
+        (part ?H ?SH))) Likely))
+
+(=>
+  (and
+    (instance ?SH Shovel)
+    (instance ?H Handle)
+    (part ?H ?SH))
+  (modalAttribute
+    (material Wood ?H) Likely))
 
 (=>
   (and
@@ -959,12 +998,13 @@
     (instance ?H Handle)
     (part ?H ?SH)
     (lever ?ROT ?H))
-  (exists (?HAND)
-    (and
-      (instance ?HAND Hand)
-      (part ?HAND ?PERSON)
-      (grasps ?PERSON ?H)
-      (fulcrum ?ROT ?HAND))))
+  (modalAttribute
+    (exists (?HAND)
+      (and
+        (instance ?HAND Hand)
+        (part ?HAND ?PERSON)
+        (grasps ?PERSON ?H)
+        (fulcrum ?ROT ?HAND))) Likely))
 
 (=>
   (and


### PR DESCRIPTION
Closes the comment Pease left on PR #562 (the Shovel-fulcrum rule was the most common case but not universal, so a `modalAttribute Likely` or `hasPurpose` wrapper was requested). Phase 0 review of the existing Shovel axioms surfaced a deeper related issue: the strict-existence rule that every Shovel has a Handle was also overcommitted. The essential digging component is the ShovelHead, not the Handle; a small child with a bare blade can still build a sandcastle.

New term (Objects.kif):

- ShovelHead: subclass EngineeringComponent, sibling of RakeHead. The working end of a Shovel; the broad rigid blade that engages the loose material being dug. Rigid is required. Material Metal Likely and shape Concave Likely (the doc-string claims that previously floated on the Shovel block, now scoped to the component where they actually apply). typicalPart and typicallyContainsPart relate it to Shovel. The documentation explicitly names the Handle-ShovelHead joint as the alternative fulcrum site for the difficult-ground case from the PR #562 comment.

Shovel rule revisions (Objects.kif):

- Strict-existence component requirement moved from Handle to ShovelHead. Every Shovel has at least one ShovelHead part.
- Handle existence on Shovel weakened from strict to modalAttribute Likely. Captures the typical-case Handle without forcing every Shovel instance to have one.
- The per-part material refactor pattern from PR #559 (Rake) applied to Shovel: the Shovel-level Metal-or-Wood Likely disjunction is removed. ShovelHead is Metal Likely (in its own block). Any Handle that is part of a Shovel is Wood Likely (new rule on Shovel).
- The Hand-grasping-Handle fulcrum binding from PR #562 wrapped in modalAttribute Likely. The Hand is the most common fulcrum; in difficult ground or rock-prying the fulcrum can shift to the Handle-ShovelHead joint per the PR #562 comment. The typical case is preserved; the alternative is named in the ShovelHead documentation and deferred to a follow-on PR that adds a term for the joint.

Out of scope, queued for follow-on:

- The geometric handle-length / hole-depth constraint surfaced in the planning conversation: an operator's reach is bounded by the local-maximum concavity of the hole, so Handle length must exceed hole depth for the user to remain outside the hole during a Digging. Requires LengthMeasure and depth predicates that are SUMO-expressible but pull in measurement axiomatization.
- A named term for the Handle-ShovelHead joint so the alternative-fulcrum case can be a first-class axiom rather than doc-string flavor.

Validation: Objects.kif paren balance 974 / 974. KifFileChecker on the changed file exits clean. All consequents on Shovel that describe typical mechanical states are now wrapped in modalAttribute Likely; the only strict-implication consequent left on Shovel is the ShovelHead structural existence.