### PR TITLE
Add ArtificialIntelligenceAgent and Sensing to Merge.kif

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -1678,6 +1678,37 @@ not also instances of &%Human.  For example, &%Primates, dolphins,
 whales, and some extraterrestrials (if they exist) might be considered
 &%CognitiveAgents.")
 
+(subclass ArtificialIntelligenceAgent AutonomousAgent)
+
+(documentation ArtificialIntelligenceAgent EnglishLanguage "An &%AutonomousAgent
+realized in software whose behavior involves autonomous decision-making, either
+through trained machine-learning models or rule-based reasoning, without
+per-decision human input.  Examples include large language models,
+reinforcement-learning agents, neural and rule-based fuzzers, static and dynamic
+analysis tools that issue findings, and automated code reviewers.  An
+&%ArtificialIntelligenceAgent engages in &%Sensing to receive environmental input
+and acts on that input through subsequent &%Processes; this is the engineering
+sense of agent-environment interaction characterized in Russell and Norvig,
+Artificial Intelligence: A Modern Approach.  An &%ArtificialIntelligenceAgent is
+not an &%Organization (it is not a collective of &%Humans).  Under the current
+scientific consensus an &%ArtificialIntelligenceAgent does not possess
+&%Perception or &%ConsciousnessAttribute and is therefore not a &%SentientAgent;
+this commitment is encoded as a disjointness axiom below and may be revised if
+future &%AutonomousAgent instances of this class are demonstrated to possess
+perception and consciousness in the senses defined elsewhere in this ontology.
+For purposes of accountability and fault, an &%ArtificialIntelligenceAgent's
+actions attribute to the &%Human or &%Organization that operates it (see
+&%operator).  The definition aligns with NIST AI Risk Management Framework (AI
+100-1) section 2.1 and ISO/IEC 42001:2023 section 3.")
+
+(disjoint ArtificialIntelligenceAgent SentientAgent)
+
+(disjoint ArtificialIntelligenceAgent Organization)
+
+(=>
+  (instance ?AI ArtificialIntelligenceAgent)
+  (capability Sensing agent ?AI))
+
 (instance LegalPersonhood RelationalAttribute)
 
 (documentation LegalPersonhood EnglishLanguage "&%LegalPersonhood is an &%Attribute of an
@@ -1758,6 +1789,32 @@ is the &%Class of all &%Processes that require exactly one &%agent in order to o
             (agent ?PROC ?AGENT3)
             (not
               (equal ?AGENT3 ?AGENT1)))))))
+
+(subclass Sensing SingleAgentProcess)
+(subclass Sensing DualObjectProcess)
+
+(documentation Sensing EnglishLanguage "A &%Process in which a non-biological
+&%Object or &%AutonomousAgent (the sensor) receives, detects, or processes a
+signal originating outside itself.  Distinguished from &%Perception, which is
+biologically scoped to &%Animal agents and is a &%PsychologicalProcess.
+&%Sensing covers non-biological input reception across devices and computational
+agents: smoke detectors, security cameras, network intrusion detection sensors,
+IoT environmental sensors, large language models receiving prompt tokens,
+fuzzers reading program output, static analysis tools parsing source code.
+Every &%Sensing instance has exactly one &%agent (the sensor) and two
+non-identical &%patient relations holding between the process and (a) the sensor
+itself and (b) the signal being received.  This term provides the engineering
+sense counterpart to &%Perception in line with the sense-act agent
+characterization in Russell and Norvig, Artificial Intelligence: A Modern
+Approach, while preserving SUMO's existing biological scoping of
+&%Perception.")
+
+(=>
+  (and
+    (instance ?S Sensing)
+    (agent ?S ?SENSOR))
+  (not
+    (instance ?SENSOR Animal)))
 
 (subclass Abstract Entity)
 (disjointDecomposition Abstract Quantity Attribute Relation Proposition List)

--- a/english_format.kif
+++ b/english_format.kif
@@ -905,9 +905,15 @@
 
 (termFormat EnglishLanguage CognitiveAgent "cognitive agent")
 
+(termFormat EnglishLanguage ArtificialIntelligenceAgent "artificial intelligence agent")
+
+(termFormat EnglishLanguage ArtificialIntelligenceAgent "AI agent")
+
 (termFormat EnglishLanguage Process "process")
 
 (termFormat EnglishLanguage DualObjectProcess "dual object process")
+
+(termFormat EnglishLanguage Sensing "sensing")
 
 (termFormat EnglishLanguage Abstract "abstract")
 


### PR DESCRIPTION
Adds two new terms to Merge.kif. ArtificialIntelligenceAgent is a direct subclass of AutonomousAgent, sibling of SentientAgent and Organization, for autonomous decision-making software agents that are not conscious and not collectives of humans. Sensing is a Process type giving SUMO an engineering-sense counterpart to Perception, which remains restricted to Animal agents per the existing axiom at Merge.kif line 13635.

ArtificialIntelligenceAgent is disjoint from Organization and, under the current scientific consensus, disjoint from SentientAgent. The SentientAgent disjointness is flagged as revisable in the documentation string, since SUMO is otherwise substrate-neutral on sentience.

Sensing is a subclass of both SingleAgentProcess and DualObjectProcess. A short axiom excludes Animal agents from Sensing, keeping the boundary with Perception sharp.

A capability axiom links the two terms: every ArtificialIntelligenceAgent is capable of being the agent of a Sensing process.

Validation: paren balance preserved on the modified Merge.kif and english_format.kif. KifFileChecker run on the modified Merge.kif reports no new errors or warnings attributable to the additions; pre-existing warnings on unrelated content unchanged.

Closes jdev-02/sumo#2. References ontologyportal/sumo#552.