### PR TITLE
Fix duplicate variable in Handgun hasPurpose exists binder

### DIFF
--- a/Mid-level-ontology.kif
+++ b/Mid-level-ontology.kif
@@ -2082,7 +2082,7 @@ single hand.[Wikipedia]")
 (=>
   (instance ?GUN Handgun)
   (hasPurpose ?GUN
-    (exists (?MAN ?S ?H ?G ?S)
+    (exists (?MAN ?S ?H ?G)
       (and
         (instance ?MAN Human)
         (instance ?S Shooting)


### PR DESCRIPTION
The existential binder in the Handgun hasPurpose rule in Mid-level-ontology.kif lists ?S twice: (exists (?MAN ?S ?H ?G ?S) ...). The body references ?MAN, ?S, ?H, ?G, with an inner exists introducing ?H2; the second ?S in the binder is vestigial and shadows the first within the same quantifier scope.

The shadowed binding causes com.articulate.sigma.trans.Modals to emit a malformed THF conjunction for this axiom (ax10761 in a freshly generated SUMO_modals.thf). LEO-III then fails at the parse step with SyntaxError, Unrecognized thf formula input 'RPAREN', and cannot complete a typecheck pass over the rest of the KB.

The fix removes the duplicate ?S from the binder. Semantics are unchanged: the body uses ?S consistently as the Shooting process throughout, and no other use of ?S exists at this scope.

After this change, the Modals to LEO-III pipeline gets past line 45152 of the generated THF and the typecheck pass proceeds.