### PR TITLE
Add supplier fulfillment rate to SupplyChain.kif

### DIFF
--- a/development/SupplyChain.kif
+++ b/development/SupplyChain.kif
@@ -1,0 +1,189 @@
+;; Access to and use of these products is governed by the GNU General Public
+;; License <http://www.gnu.org/copyleft/gpl.html>.
+;; By using these products, you agree to be bound by the terms
+;; of the GPL.
+
+;; We ask that people using or referencing this work cite our primary paper:
+
+;; Niles, I., and Pease, A.  2001.  Towards a Standard Upper Ontology.  In
+;; Proceedings of the 2nd International Conference on Formal Ontology in
+;; Information Systems (FOIS-2001), Chris Welty and Barry Smith, eds,
+;; Ogunquit, Maine, October 17-19, 2001.  See also www.ontologyportal.org
+
+;; A domain ontology for commercial supply-chain operations: delivery,
+;; inventory, replenishment lead time, and the order-fulfilment relations that
+;; ground a neuro-symbolic backorder-prediction pipeline. Depends on Merge.kif,
+;; Mid-level-ontology.kif, and (for PerformanceMeasure) FinancialOntology.kif.
+
+;; =======================
+;; Delivering
+;; =======================
+
+(subclass Delivering Transportation)
+(termFormat EnglishLanguage Delivering "delivering")
+
+(documentation Delivering EnglishLanguage
+  "A &%Transportation in which a &%CorpuscularObject moves from a supplier or
+   distribution-centre origin to a destination. A &%Delivering is most often the
+   fulfilment of an active &%PurchaseOrder, but the class also covers transfers
+   with no purchase, such as barter exchange or the internal redistribution of
+   goods within an organization. As a &%Translocation, a &%Delivering carries its
+   &%patient from its &%origin to its &%destination over the extent of the process;
+   for a &%Delivering both the &%origin and the &%destination are instances of
+   &%GeographicArea, and the patient is the &%CorpuscularObject being shipped. The
+   in-transit state of units whose &%Delivering has begun but not terminated is
+   formalized with the in-transit terms of this series.")
+
+(=>
+  (instance ?d Delivering)
+  (exists (?p)
+    (and (patient ?d ?p)
+         (instance ?p CorpuscularObject))))
+
+(=>
+  (instance ?d Delivering)
+  (exists (?o)
+    (and (origin ?d ?o)
+         (instance ?o GeographicArea))))
+
+(=>
+  (instance ?d Delivering)
+  (exists (?dest)
+    (and (destination ?d ?dest)
+         (instance ?dest GeographicArea))))
+
+(=>
+  (instance ?d Delivering)
+  (modalAttribute
+    (exists (?po)
+      (and (instance ?po PurchaseOrder)
+           (refers ?po ?d)))
+    Likely))
+
+;; =======================
+;; National Inventory Count
+;; =======================
+
+(instance nationalInventoryCount BinaryRelation)
+(domain nationalInventoryCount 1 CorpuscularObject)
+(domain nationalInventoryCount 2 NonnegativeRealNumber)
+(termFormat EnglishLanguage nationalInventoryCount "national inventory count")
+
+(documentation nationalInventoryCount EnglishLanguage
+  "A count of product units physically available for order fulfillment,
+   scoped to a national &%GeographicArea. The count is a &%NonnegativeRealNumber.
+   Negative values indicate an ERP data-integrity failure and are not valid
+   inventory states. A value greater than zero confers the &%capability for the
+   product to be the patient of a &%Delivering process. Zero denotes either an
+   empty stock position or an unlogged entry; discrimination between these cases
+   requires contextual inference and is not resolvable at the ontological layer.")
+
+(=>
+  (and (nationalInventoryCount ?sku ?qty)
+       (greaterThan ?qty 0))
+  (capability Delivering patient ?sku))
+
+;; =======================
+;; Lead Time Duration
+;; =======================
+
+(instance leadTimeDuration BinaryRelation)
+(domain leadTimeDuration 1 CorpuscularObject)
+(domain leadTimeDuration 2 TimeDuration)
+(termFormat EnglishLanguage leadTimeDuration "lead time duration")
+
+(documentation leadTimeDuration EnglishLanguage
+  "The &%TimeDuration in &%DayDuration units between order placement and
+   supplier &%Delivering for a given &%CorpuscularObject. When present,
+   the value must be a &%PositiveRealNumber: zero is physically impossible
+   for external replenishment. Absence of any asserted value is ontologically
+   valid and may reflect no &%serviceLevelAgreement from the supplier, a
+   &%LocallyStocked item where external replenishment is inapplicable, or simply
+   no &%historicalLeadTime recorded yet, as for a newly introduced product or
+   customer. Discrimination between these cases requires modal inference over
+   contextual attributes and is not resolvable at the ontological layer.")
+
+(=>
+  (leadTimeDuration ?sku ?dur)
+  (exists (?n)
+    (and (instance ?n PositiveRealNumber)
+         (equal ?dur (MeasureFn ?n DayDuration)))))
+
+;; =======================
+;; Supporting terms for the lead-time absence explanation
+;; =======================
+
+(instance serviceLevelAgreement BinaryPredicate)
+(domain serviceLevelAgreement 1 Agreement)
+(domain serviceLevelAgreement 2 CorpuscularObject)
+(termFormat EnglishLanguage serviceLevelAgreement "service level agreement")
+
+(documentation serviceLevelAgreement EnglishLanguage
+  "(&%serviceLevelAgreement ?SLA ?PRODUCT) means the &%Agreement ?SLA specifies
+   contractual fulfilment terms, including replenishment lead time, for the
+   &%CorpuscularObject ?PRODUCT. A product covered by a service level agreement is
+   therefore likely to have a defined &%leadTimeDuration.")
+
+(=>
+  (serviceLevelAgreement ?sla ?sku)
+  (modalAttribute (exists (?dur) (leadTimeDuration ?sku ?dur)) Likely))
+
+(instance contractualObligation BinaryPredicate)
+(domain contractualObligation 1 Agreement)
+(domain contractualObligation 2 CorpuscularObject)
+(termFormat EnglishLanguage contractualObligation "contractual obligation")
+
+(documentation contractualObligation EnglishLanguage
+  "(&%contractualObligation ?AGREEMENT ?PRODUCT) means the &%Agreement ?AGREEMENT
+   imposes a binding supply obligation with respect to the &%CorpuscularObject
+   ?PRODUCT. A product under a contractual obligation is likely covered by a
+   &%serviceLevelAgreement.")
+
+(=>
+  (contractualObligation ?agr ?sku)
+  (modalAttribute (exists (?sla) (serviceLevelAgreement ?sla ?sku)) Likely))
+
+(instance historicalLeadTime BinaryPredicate)
+(domain historicalLeadTime 1 TimeDuration)
+(domain historicalLeadTime 2 CorpuscularObject)
+(termFormat EnglishLanguage historicalLeadTime "historical lead time")
+
+(documentation historicalLeadTime EnglishLanguage
+  "(&%historicalLeadTime ?DURATION ?PRODUCT) records an observed past
+   replenishment &%TimeDuration ?DURATION, in &%DayDuration units, for the
+   &%CorpuscularObject ?PRODUCT. A recorded duration is a &%PositiveRealNumber.")
+
+(=>
+  (historicalLeadTime ?h ?sku)
+  (exists (?n)
+    (and (instance ?n PositiveRealNumber)
+         (equal ?h (MeasureFn ?n DayDuration)))))
+
+(instance LocallyStocked Attribute)
+(termFormat EnglishLanguage LocallyStocked "locally stocked")
+
+(documentation LocallyStocked EnglishLanguage
+  "An &%Attribute asserting that a &%CorpuscularObject is replenished from local
+   stock rather than external supplier &%Delivering, so external replenishment
+   lead time is inapplicable to it.")
+
+(=>
+  (attribute ?sku LocallyStocked)
+  (modalAttribute
+    (not (exists (?dur) (leadTimeDuration ?sku ?dur))) Likely))
+
+;; Lead-time absence: contextual explanations
+
+(=>
+  (and (instance ?sku CorpuscularObject)
+       (not (exists (?dur) (leadTimeDuration ?sku ?dur)))
+       (not (exists (?contract) (contractualObligation ?contract ?sku))))
+  (modalAttribute
+    (not (exists (?sla) (serviceLevelAgreement ?sla ?sku))) Likely))
+
+(=>
+  (and (instance ?sku CorpuscularObject)
+       (not (exists (?dur) (leadTimeDuration ?sku ?dur)))
+       (modalAttribute (attribute ?sku LocallyStocked) Likely))
+  (modalAttribute
+    (not (capability Delivering patient ?sku)) Likely))

--- a/development/SupplyChain.kif
+++ b/development/SupplyChain.kif
@@ -292,3 +292,115 @@
 (=>
   (attribute ?sku DataIntegrityViolation)
   (instance ?sku CorpuscularObject))
+
+;; ============================================================
+;; Add supplier fulfillment rate to SupplyChain.kif
+;; ============================================================
+
+(subclass FulfillmentRate PerformanceMeasure)
+(termFormat EnglishLanguage FulfillmentRate "fulfillment rate")
+
+(documentation FulfillmentRate EnglishLanguage
+  "A &%PerformanceMeasure naming the ratio of &%Delivering events completed to
+   &%Delivering events requested for a &%CorpuscularObject over a specified
+   &%TimeDuration. The reported value, carried by &%supplierFulfillmentRate, is a
+   &%NonnegativeRealNumber bounded above by 1: zero indicates no fulfillment occurred
+   or the metric was not logged; 1 indicates complete fulfillment. Values are produced
+   by applying &%AverageFn to a &%List of per-period fill ratios across the window. A
+   value of zero where &%historicalSalesVolume is nonzero for the same &%CorpuscularObject
+   and window indicates a data logging gap. The shorter-window value relative to a
+   longer-window value signals recent performance trend direction.")
+
+(instance supplierFulfillmentRate TernaryRelation)
+(domain supplierFulfillmentRate 1 CorpuscularObject)
+(domain supplierFulfillmentRate 2 TimeDuration)
+(domain supplierFulfillmentRate 3 NonnegativeRealNumber)
+(termFormat EnglishLanguage supplierFulfillmentRate "supplier fulfillment rate")
+
+(documentation supplierFulfillmentRate EnglishLanguage
+  "(&%supplierFulfillmentRate ?PRODUCT ?WINDOW ?VALUE) holds the &%FulfillmentRate
+   ?VALUE, a &%NonnegativeRealNumber in the interval from 0 to 1, achieved for the
+   &%CorpuscularObject ?PRODUCT over the trailing &%TimeDuration ?WINDOW.")
+
+(=>
+  (supplierFulfillmentRate ?sku ?window ?val)
+  (and (instance ?val NonnegativeRealNumber)
+       (lessThanOrEqualTo ?val 1)))
+
+(=>
+  (supplierFulfillmentRate ?sku ?window ?val)
+  (exists (?list)
+    (and (instance ?list List)
+         (equal ?val (AverageFn ?list)))))
+
+(=>
+  (and (supplierFulfillmentRate ?sku ?window 0)
+       (exists (?count)
+         (and (historicalSalesVolume ?sku ?window ?count)
+              (greaterThan ?count 0))))
+  (modalAttribute (dataLoggingGap ?sku ?window) Likely))
+
+(=>
+  (and (supplierFulfillmentRate ?sku ?windowShort 0)
+       (supplierFulfillmentRate ?sku ?windowLong 0)
+       (greaterThan ?windowLong ?windowShort))
+  (modalAttribute
+    (not (exists (?s)
+           (and (instance ?s Selling)
+                (patient ?s ?sku))))
+    Likely))
+
+(=>
+  (and (supplierFulfillmentRate ?sku ?windowShort ?valShort)
+       (supplierFulfillmentRate ?sku ?windowLong ?valLong)
+       (greaterThan ?windowLong ?windowShort)
+       (lessThan ?valShort ?valLong))
+  (modalAttribute (attribute ?sku RecentPerformanceDegradation) Likely))
+
+(=>
+  (and (supplierFulfillmentRate ?sku ?windowShort ?valShort)
+       (supplierFulfillmentRate ?sku ?windowLong ?valLong)
+       (greaterThan ?windowLong ?windowShort)
+       (greaterThan ?valShort ?valLong))
+  (modalAttribute (attribute ?sku RecentPerformanceImprovement) Likely))
+
+;; Supporting terms
+
+(instance dataLoggingGap BinaryPredicate)
+(domain dataLoggingGap 1 CorpuscularObject)
+(domain dataLoggingGap 2 TimeDuration)
+(termFormat EnglishLanguage dataLoggingGap "data logging gap")
+
+(documentation dataLoggingGap EnglishLanguage
+  "(&%dataLoggingGap ?PRODUCT ?WINDOW) means a reported zero metric value for the
+   &%CorpuscularObject ?PRODUCT over the &%TimeDuration ?WINDOW is attributable to a
+   gap in data logging rather than to a true absence of activity.")
+
+(=>
+  (dataLoggingGap ?sku ?window)
+  (modalAttribute (attribute ?sku DataIntegrityViolation) Likely))
+
+(instance RecentPerformanceDegradation Attribute)
+(termFormat EnglishLanguage RecentPerformanceDegradation "recent performance degradation")
+
+(documentation RecentPerformanceDegradation EnglishLanguage
+  "An &%Attribute marking a &%CorpuscularObject whose shorter-window
+   &%supplierFulfillmentRate is below its longer-window value, indicating a recent
+   decline in supplier performance. Mutually exclusive with
+   &%RecentPerformanceImprovement.")
+
+(=>
+  (attribute ?sku RecentPerformanceDegradation)
+  (not (attribute ?sku RecentPerformanceImprovement)))
+
+(instance RecentPerformanceImprovement Attribute)
+(termFormat EnglishLanguage RecentPerformanceImprovement "recent performance improvement")
+
+(documentation RecentPerformanceImprovement EnglishLanguage
+  "An &%Attribute marking a &%CorpuscularObject whose shorter-window
+   &%supplierFulfillmentRate exceeds its longer-window value, indicating a recent
+   improvement in supplier performance.")
+
+(=>
+  (attribute ?sku RecentPerformanceImprovement)
+  (instance ?sku CorpuscularObject))

--- a/development/SupplyChain.kif
+++ b/development/SupplyChain.kif
@@ -187,3 +187,108 @@
        (modalAttribute (attribute ?sku LocallyStocked) Likely))
   (modalAttribute
     (not (capability Delivering patient ?sku)) Likely))
+
+;; ============================================================
+;; Add historical sales volume to SupplyChain.kif
+;; ============================================================
+
+(instance historicalSalesVolume TernaryRelation)
+(domain historicalSalesVolume 1 CorpuscularObject)
+(domain historicalSalesVolume 2 TimeDuration)
+(domain historicalSalesVolume 3 NonnegativeRealNumber)
+(termFormat EnglishLanguage historicalSalesVolume "historical sales volume")
+
+(documentation historicalSalesVolume EnglishLanguage
+  "A &%TernaryRelation mapping a &%CorpuscularObject (the product SKU),
+   a &%TimeDuration window expressed as &%MeasureFn applied to a
+   &%PositiveInteger and &%MonthDuration, and a &%NonnegativeRealNumber
+   count of completed &%Selling events in which the product was patient
+   within that trailing window. A &%Selling event requires an exchange of
+   &%CurrencyMeasure for a &%Physical object; partial or unfilled orders
+   do not qualify. A count of zero is ontologically valid only when the
+   customer relationship age is likely less than the window &%TimeDuration;
+   for an established account zero likely exhibits a &%DataIntegrityViolation.
+   A nonzero count confirms the product was patient of at least one
+   completed &%Delivering within the window.")
+
+(=>
+  (historicalSalesVolume ?sku ?window ?count)
+  (exists (?n)
+    (and (instance ?n PositiveInteger)
+         (equal ?window (MeasureFn ?n MonthDuration)))))
+
+(=>
+  (and (historicalSalesVolume ?sku ?window ?count)
+       (greaterThan ?count 0))
+  (exists (?sale)
+    (and (instance ?sale Selling)
+         (patient ?sale ?sku))))
+
+(=>
+  (and (historicalSalesVolume ?sku ?window ?count)
+       (greaterThan ?count 0))
+  (exists (?delivery)
+    (and (instance ?delivery Delivering)
+         (patient ?delivery ?sku))))
+
+(=>
+  (and (historicalSalesVolume ?sku ?window 0)
+       (modalAttribute
+         (exists (?age)
+           (and (customerRelationshipAge ?sku ?age)
+                (lessThan ?age ?window)))
+         Likely))
+  (modalAttribute (attribute ?sku NewAccountException) Likely))
+
+(=>
+  (and (historicalSalesVolume ?sku ?window 0)
+       (not
+         (modalAttribute
+           (exists (?age)
+             (and (customerRelationshipAge ?sku ?age)
+                  (lessThan ?age ?window)))
+           Likely)))
+  (modalAttribute (attribute ?sku DataIntegrityViolation) Likely))
+
+;; Supporting terms
+
+(instance customerRelationshipAge BinaryPredicate)
+(domain customerRelationshipAge 1 CorpuscularObject)
+(domain customerRelationshipAge 2 TimeDuration)
+(termFormat EnglishLanguage customerRelationshipAge "customer relationship age")
+
+(documentation customerRelationshipAge EnglishLanguage
+  "(&%customerRelationshipAge ?PRODUCT ?DURATION) means the customer relationship
+   under which the &%CorpuscularObject ?PRODUCT is ordered has been active for the
+   &%TimeDuration ?DURATION, measured in &%DayDuration units. Used to distinguish a
+   legitimate zero &%historicalSalesVolume on a young account from a data fault.")
+
+(=>
+  (customerRelationshipAge ?sku ?age)
+  (exists (?n)
+    (and (instance ?n PositiveRealNumber)
+         (equal ?age (MeasureFn ?n DayDuration)))))
+
+(instance NewAccountException Attribute)
+(termFormat EnglishLanguage NewAccountException "new account exception")
+
+(documentation NewAccountException EnglishLanguage
+  "An &%Attribute marking a &%CorpuscularObject whose zero &%historicalSalesVolume
+   is explained by a customer relationship younger than the sales window rather than
+   by a data fault. Mutually exclusive with &%DataIntegrityViolation.")
+
+(=>
+  (attribute ?sku NewAccountException)
+  (not (attribute ?sku DataIntegrityViolation)))
+
+(instance DataIntegrityViolation Attribute)
+(termFormat EnglishLanguage DataIntegrityViolation "data integrity violation")
+
+(documentation DataIntegrityViolation EnglishLanguage
+  "An &%Attribute marking a &%CorpuscularObject whose recorded supply-chain data,
+   such as a zero &%historicalSalesVolume on an established account, is inconsistent
+   with its true state and requires correction.")
+
+(=>
+  (attribute ?sku DataIntegrityViolation)
+  (instance ?sku CorpuscularObject))


### PR DESCRIPTION
This adds FulfillmentRate (a PerformanceMeasure) and the supplierFulfillmentRate ternary relation to SupplyChain.kif, mapping a product and window to a NonnegativeRealNumber fill ratio bounded above by 1. AverageFn grounds the averaging semantics. Modal trend axioms detect recent degradation and improvement across windows of differing length, and a logging-gap axiom cross-references historicalSalesVolume. Validated with the SigmaKEE KifFileChecker (zero errors); the range-bound inference proves with Vampire at SZS Theorem. Stacked on the part-2 branch.
