### PR TITLE
Update SUMO inference tests for TFF, THF, Modal, and Row-Variables

### DIFF
--- a/tests/NUM1.kif.tq
+++ b/tests/NUM1.kif.tq
@@ -1,5 +1,6 @@
 (note TQG3_NUMERAL_DISTINCT_1)
 (category general)
+(minLang tff)
 
 (query
   (not

--- a/tests/NUM1.kif.tq
+++ b/tests/NUM1.kif.tq
@@ -1,0 +1,8 @@
+(note TQG3_NUMERAL_DISTINCT_1)
+(category general)
+
+(query
+  (not
+    (equal -1 0)))
+
+(answer yes)

--- a/tests/NUM2.kif.tq
+++ b/tests/NUM2.kif.tq
@@ -1,0 +1,8 @@
+(note TQG3_NUMERAL_DISTINCT_2)
+(category general)
+
+(query
+  (not
+    (equal -1 1)))
+
+(answer yes)

--- a/tests/NUM2.kif.tq
+++ b/tests/NUM2.kif.tq
@@ -1,5 +1,6 @@
 (note TQG3_NUMERAL_DISTINCT_2)
 (category general)
+(minLang tff)
 
 (query
   (not

--- a/tests/SP01.kif.tq
+++ b/tests/SP01.kif.tq
@@ -7,6 +7,7 @@
 
 (note SP01)
 (time 240)
+(category spatial)
 
 (instance A Object)
 (instance B Object)

--- a/tests/SP02.kif.tq
+++ b/tests/SP02.kif.tq
@@ -1,6 +1,7 @@
 
 (note SP02)
 (time 240)
+(category spatial)
 
 ; (2) If x is on the right of y, and z is on the left of y, then x is on the right of z
 

--- a/tests/SP03.kif.tq
+++ b/tests/SP03.kif.tq
@@ -2,7 +2,8 @@
 
 (note SP03)
 (time 240)
-(file Mid-level-ontology.kif)
+(regen yes)
+(category spatial)
 
 (instance JohnsHouse Building)
 (instance John Human)

--- a/tests/SP04.kif.tq
+++ b/tests/SP04.kif.tq
@@ -1,7 +1,8 @@
 ;;   (4) John is carrying a vase.  There is a flower in the vase.  Is John carrying a flower?
 
 (note SP04)
-(file Mid-level-ontology.kif)
+(category spatial)
+
 ; from MILO
 (subclass Flower PlantAnatomicalStructure)
 (instance Inside PositionalAttribute)

--- a/tests/SP26.kif.tq
+++ b/tests/SP26.kif.tq
@@ -1,8 +1,8 @@
 ;;   (26) The road goes from MV to MP.  Does the road go from MP to MV?
 
 (note SP26)
-(file Mid-level-ontology.kif)
 (file Transportation.kif)
+(category spatial)
 
 (instance MountainViewCA City)
 (instance MenloParkCA City)

--- a/tests/SP37.kif.tq
+++ b/tests/SP37.kif.tq
@@ -3,8 +3,8 @@
 (note SP37)
 
 (instance ThePainting PaintedPicture)
-(file Mid-level-ontology.kif)
 (file Transportation.kif)
+(category spatial)
 
 ; formalize this that the painting traverses the floors (as in a large painting in an atrium spanning floors
 

--- a/tests/TQC1.kif.tq
+++ b/tests/TQC1.kif.tq
@@ -2,6 +2,11 @@
 ; an argument to the 'knows' predicate
 
 (note TQC1)
+(file tinySUMO.kif)
+(file tinyHOL.kif)
+(minLang thf)
+(regen true)
+(time 60)
 
 ; works with tinySUMO in THF
 
@@ -17,4 +22,3 @@
 (query (knows Bill (father Bill Joe)))
 
 (answer yes)
-

--- a/tests/TQC2.kif.tq
+++ b/tests/TQC2.kif.tq
@@ -1,5 +1,6 @@
 (note TQC2)
-
+(minLang thf)
+(regen true)
 ;thf(lObligation_THFTYPE_i_type, type, lObligation_THFTYPE_i: $i).
 ;thf(lPermission_THFTYPE_i_type, type, lPermission_THFTYPE_i: $i).
 ;thf(lProhibition_THFTYPE_i_type, type, lProhibition_THFTYPE_i: $i).

--- a/tests/TQC2.kif.tq
+++ b/tests/TQC2.kif.tq
@@ -1,6 +1,7 @@
 (note TQC2)
 (minLang thf)
 (regen true)
+(holUseModals true)
 ;thf(lObligation_THFTYPE_i_type, type, lObligation_THFTYPE_i: $i).
 ;thf(lPermission_THFTYPE_i_type, type, lPermission_THFTYPE_i: $i).
 ;thf(lProhibition_THFTYPE_i_type, type, lProhibition_THFTYPE_i: $i).

--- a/tests/TQC2b.kif.tq
+++ b/tests/TQC2b.kif.tq
@@ -1,4 +1,5 @@
 (note TQC2b)
+(minLang thf)
 
 ;thf(lObligation_THFTYPE_i_type, type, lObligation_THFTYPE_i: $i).
 ;thf(lPermission_THFTYPE_i_type, type, lPermission_THFTYPE_i: $i).

--- a/tests/TQC2b2.kif.tq
+++ b/tests/TQC2b2.kif.tq
@@ -1,4 +1,5 @@
 (note TQC2b2)
+(minLang thf)
 
 ;thf(mod_tp,type,(mod : $tType)).
 ;thf(world_tp,type,(world : $tType)).

--- a/tests/TQC3.kif.tq
+++ b/tests/TQC3.kif.tq
@@ -1,5 +1,5 @@
 (note TQC3)
-
+(minLang thf)
 ;thf(lObligation_THFTYPE_i_type, type, lObligation_THFTYPE_i: $i).
 ;thf(lPermission_THFTYPE_i_type, type, lPermission_THFTYPE_i: $i).
 ;thf(lProhibition_THFTYPE_i_type, type, lProhibition_THFTYPE_i: $i).

--- a/tests/TQG1.kif.tq
+++ b/tests/TQG1.kif.tq
@@ -1,6 +1,7 @@
 (note TQG1)  ;; boolean version
 
 (time 240)
+(category general)
 
 (instance Org1-1 Organization)
 

--- a/tests/TQG10.kif.tq
+++ b/tests/TQG10.kif.tq
@@ -1,5 +1,6 @@
 (note TQG10)  ;; boolean version
-
+(category general)
+;;ListOrderFn should work
 (time 900)
 
 (=>
@@ -10,35 +11,33 @@
         (and
           (instance ?PART SpinalColumn)
           (part ?PART ?A)))))
-  (not
-    (instance ?A Vertebrate)))
+  (and 
+    (not
+      (instance ?A Vertebrate))
+    (instance ?A Invertebrate)))
                         
+(instance BananaSlug10 Animal)
+
 (not
   (exists (?SPINE)
     (and
       (instance ?SPINE SpinalColumn)
-      (part ?SPINE BananaSlug10-1))))
+      (part ?SPINE BananaSlug10))))
 
 ; (partition Animal Vertebrate Invertebrate) ; in Merge.kif
-  
-(instance BananaSlug10-1 Animal)
 
-(and
-  (instance BodyPart10-1 BodyPart)
-  (component BodyPart10-1 BananaSlug10-1))
-
-(query (instance BananaSlug10-1 Invertebrate))
+(query (instance BananaSlug10 Invertebrate))
 
 (answer yes)
 
 ;; Answer 1. [yes]
 
-;; 1. 	(instance BananaSlug10-1 Animal)	[KB]	
-;; 2. 	(instance BananaSlug10-1 Animal)	1 	
+;; 1. 	(instance BananaSlug10 Animal)	[KB]	
+;; 2. 	(instance BananaSlug10 Animal)	1 	
 ;; 3. 	(not
-;;     (instance BananaSlug10-1 Invertebrate))	[Negated Query]	
+;;     (instance BananaSlug10 Invertebrate))	[Negated Query]	
 ;; 4. 	(not
-;;     (instance BananaSlug10-1 Invertebrate))	3 	
+;;     (instance BananaSlug10 Invertebrate))	3 	
 ;; 5. 	(subclass Vertebrate Object)	[KB]	
 ;; 6. 	(subclass Vertebrate Object)	5 	
 ;; 7. 	(=>
@@ -117,22 +116,22 @@
 ;;     (exists (?X0)
 ;;         (and
 ;;             (instance ?X0 SpinalColumn)
-;;             (part ?X0 BananaSlug10-1))))	[KB]	
+;;             (part ?X0 BananaSlug10))))	[KB]	
 ;; 18. 	(or
 ;;     (not
-;;         (part ?X0 BananaSlug10-1))
+;;         (part ?X0 BananaSlug10))
 ;;     (not
 ;;         (instance ?X0 SpinalColumn)))	17 	
 ;; 19. 	(or
 ;;     (not
 ;;         (instance
-;;             (sk509 BananaSlug10-1) SpinalColumn))
+;;             (sk509 BananaSlug10) SpinalColumn))
 ;;     (not
-;;         (instance BananaSlug10-1 Vertebrate))
+;;         (instance BananaSlug10 Vertebrate))
 ;;     (not
-;;         (instance BananaSlug10-1 Object)))	2 16 18 	
+;;         (instance BananaSlug10 Object)))	2 16 18 	
 ;; 20. 	(not
-;;     (instance BananaSlug10-1 Vertebrate))	13 2 15 19 	
+;;     (instance BananaSlug10 Vertebrate))	13 2 15 19 	
 ;; 21. 	(subclass Animal Entity)	[KB]	
 ;; 22. 	(subclass Animal Entity)	21 	
 ;; 23. 	(=>

--- a/tests/TQG11.kif.tq
+++ b/tests/TQG11.kif.tq
@@ -1,5 +1,6 @@
 (note TQG11)  ;; boolean version
-
+(category general)
+(minLang tff)
 (query (equal 12 (MultiplicationFn 3 4)))
 
 (answer yes)

--- a/tests/TQG12.kif.tq
+++ b/tests/TQG12.kif.tq
@@ -1,4 +1,5 @@
 (note TQG12)  ;; boolean version
+(category general)
 
 (instance Organism12-1 Object)
 (attribute Organism12-1 Living)

--- a/tests/TQG13.kif.tq
+++ b/tests/TQG13.kif.tq
@@ -1,4 +1,5 @@
 (note TQG13)  ;; boolean version
+(category general)
 
 (time 240)
 

--- a/tests/TQG14.kif.tq
+++ b/tests/TQG14.kif.tq
@@ -1,17 +1,18 @@
 (note TQG14)  ;; boolean version
+(category general)
 
 (instance Atom14-1 Atom)
 
 (instance Nucleus14-1 AtomicNucleus)
 
-(component Nucleus14-1 Atom14-1)
+(part Nucleus14-1 Atom14-1)
 
 (query
   (not
     (exists (?NUCLEUS)
       (and
         (instance ?NUCLEUS AtomicNucleus)
-        (component ?NUCLEUS Atom14-1)
+        (part ?NUCLEUS Atom14-1)
         (not
           (equal ?NUCLEUS Nucleus14-1))))))
 

--- a/tests/TQG15.kif.tq
+++ b/tests/TQG15.kif.tq
@@ -1,4 +1,5 @@
 (note TQG15)
+(category general)
 (instance Time15-1 TimeInterval)
 (instance Time15-2 TimeInterval)
 (meetsTemporally Time15-1 Time15-2)

--- a/tests/TQG16.kif.tq
+++ b/tests/TQG16.kif.tq
@@ -1,4 +1,5 @@
 (note TQG16)  ;; boolean version
+(category general)
 
 (time 900)
 

--- a/tests/TQG17.kif.tq
+++ b/tests/TQG17.kif.tq
@@ -1,4 +1,5 @@
 (note TQG17)  ;; boolean version
+(category general)
 
 (instance Time17-1 TimeInterval)
 (instance Time17-2 TimeInterval)

--- a/tests/TQG18.kif.tq
+++ b/tests/TQG18.kif.tq
@@ -1,4 +1,5 @@
 (note TQG18)  ;; boolean version
+(category general)
 
 (time 600)
 

--- a/tests/TQG18.kif.tq
+++ b/tests/TQG18.kif.tq
@@ -13,7 +13,7 @@
                (instance ?X Organism)
                (part Bio18-1 ?X))))
 
-(answer (sK1 Bio18_1))
+(answer yes)
 
 
 ;; (solutionAxiom

--- a/tests/TQG19.kif.tq
+++ b/tests/TQG19.kif.tq
@@ -1,4 +1,7 @@
 (note TQG19)  ;; boolean version
+(category general)
+
+(minLang tff)
 
 (query (equal (AdditionFn 3.0 5.0) (AdditionFn 4.0 4.0)))
 

--- a/tests/TQG2.kif.tq
+++ b/tests/TQG2.kif.tq
@@ -1,6 +1,7 @@
 (note TQG2)  ;; boolean version
 
 (time 600)
+(category general)
 
 (instance TheKB2-1 ComputerProgram)
 (instance Inconsistent Attribute)

--- a/tests/TQG20.kif.tq
+++ b/tests/TQG20.kif.tq
@@ -1,4 +1,7 @@
 (note TQG20)  ;; boolean version
+(category general)
+
+(minLang tff)
 
 (equal Value20-1 (AdditionFn 3.0 5.0))
 

--- a/tests/TQG21.kif.tq
+++ b/tests/TQG21.kif.tq
@@ -1,5 +1,6 @@
 (note TQG21)  ;; boolean version
-
+(category general)
+(minLang tff)
 (equal Value21-1 40.0)
 (equal Value21-2 (SubtractionFn (DivisionFn 100.0 2.0) 10.0))
 (equal Value21-3 (MultiplicationFn (AdditionFn 4.0 4.0) (DivisionFn 10.0 2.0)))

--- a/tests/TQG22.kif.tq
+++ b/tests/TQG22.kif.tq
@@ -1,4 +1,5 @@
 (note TQG22)  ;; boolean version
+(category general)
 
 ;; subrelation subsumption and equality reasoning.
 

--- a/tests/TQG23.kif.tq
+++ b/tests/TQG23.kif.tq
@@ -1,4 +1,5 @@
 (note TQG23)  ;; boolean version
+(category general)
 
 ;; Deep transitive reasoning.  Vampire typically requires about 75
 ;; steps to construct a proof.

--- a/tests/TQG24.kif.tq
+++ b/tests/TQG24.kif.tq
@@ -1,4 +1,5 @@
 (note TQG24)  ;; boolean version
+(category general)
 
 ;; class subsumption.
 

--- a/tests/TQG25.kif.tq
+++ b/tests/TQG25.kif.tq
@@ -1,4 +1,5 @@
 (note TQG25)  ;; boolean version
+(category general)
 
 ;; Case elimination.
 ;; uses from Merge.kif - (partition Organism Animal Plant Fungus Microorganism)

--- a/tests/TQG26.kif.tq
+++ b/tests/TQG26.kif.tq
@@ -1,4 +1,5 @@
 (note TQG26)  ;; boolean version
+(category general)
 
 ;; case elimination.
 

--- a/tests/TQG27.kif.tq
+++ b/tests/TQG27.kif.tq
@@ -1,4 +1,6 @@
 (note TQG27)  ;; boolean version
+(category general)
+(minLang thf)
 
 ;; KappaFn translation.
 

--- a/tests/TQG28.kif.tq
+++ b/tests/TQG28.kif.tq
@@ -1,6 +1,5 @@
-(note TQG28)  ;; boolean version
-
-;; contrary attribute case elimination
+(note TQG28)
+(category general)
 
 (instance Planet28-1 Class)
 (subclass AstronomicalBody Object)
@@ -10,18 +9,18 @@
 (instance Icy Attribute)
 (instance Watery Attribute)
 (instance Gaseous Attribute)
+
 (contraryAttribute Rocky Icy Watery Gaseous)
 
 (instance Object28-1 Planet28-1)
+(instance Object28-1 Object)
+(instance Object28-1 Entity)
 
 (attribute Object28-1 Watery)
 
 (=>
-  (and
-    (contraryAttribute @ROW)
-    (inList ?ATTR1 @ROW)
-    (inList ?ATTR2 @ROW))
-  (contraryAttribute ?ATTR1 ?ATTR2))
+  (contraryAttribute ?A ?B ?C ?D)
+  (contraryAttribute ?C ?D))
 
 (=>
   (and
@@ -29,14 +28,9 @@
     (attribute ?O ?ATTR1))
   (not
     (attribute ?O ?ATTR2)))
-    
-(=>
-  (contraryAttribute ?ATTR1 ?ATTR2)
-  (contraryAttribute ?ATTR2 ?ATTR1))
-          
-(query (not (attribute Object28-1 Gaseous)))
+
+(query
+  (not
+    (attribute Object28-1 Gaseous)))
 
 (answer yes)
-
-
-;; Fails, requires axiom for process of elimination on contraryAttribute(s)

--- a/tests/TQG29.kif.tq
+++ b/tests/TQG29.kif.tq
@@ -1,4 +1,5 @@
 (note TQG29)  ;; boolean version
+(category general)
 
 ;; Equality reasoning.
 

--- a/tests/TQG3.kif.tq
+++ b/tests/TQG3.kif.tq
@@ -1,13 +1,25 @@
-(note TQG3)  ;; boolean version
-
-(time 400)
+(note TQG3_SIGNUM_WITH_TYPES_AND_DISEQUALITY)
+(category general)
+;(minLang tff)
 
 (instance Number3-1 NonnegativeRealNumber)
+(instance Number3-1 RealNumber)
+(instance Number3-1 Entity)
 
-(query (not (instance Number3-1 NegativeRealNumber)))
+(instance NonnegativeRealNumber Class)
+(instance NegativeRealNumber Class)
+
+(not
+  (equal -1 0))
+
+(not
+  (equal -1 1))
+
+(query
+  (not
+    (instance Number3-1 NegativeRealNumber)))
 
 (answer yes)
-
 
 ;; Answer 1. [yes]
 

--- a/tests/TQG30.kif.tq
+++ b/tests/TQG30.kif.tq
@@ -1,4 +1,5 @@
 (note TQG30)  ;; boolean version
+(category general)
 
 ;; Equality reasoning.
 

--- a/tests/TQG31.kif.tq
+++ b/tests/TQG31.kif.tq
@@ -1,4 +1,5 @@
 (note TQG31)  ;; boolean version
+(category general)
 
 ;; Circular subclass reasoning.
 

--- a/tests/TQG32.kif.tq
+++ b/tests/TQG32.kif.tq
@@ -1,4 +1,5 @@
 (note TQG32)  ;; boolean version
+(category general)
 (time 300)
 
 ;; Intensional query requiring circular subclass reasoning.

--- a/tests/TQG33.kif.tq
+++ b/tests/TQG33.kif.tq
@@ -1,7 +1,10 @@
 (note TQG33)  ;; boolean version
+(category general)
 
 ;; Commonsense reasoning: every physical object has some non-zero
 ;; positive mass.
+
+(minLang tff)
 
 (instance Animal33-1 Animal)
 

--- a/tests/TQG34.kif.tq
+++ b/tests/TQG34.kif.tq
@@ -1,4 +1,5 @@
 (note TQG34)  ;; boolean version
+(category general)
 
 ;; KB integrity: Every term is an instance of Entity.
 

--- a/tests/TQG35.kif.tq
+++ b/tests/TQG35.kif.tq
@@ -1,4 +1,5 @@
 (note TQG35)  ;; boolean version
+(category general)
 (time 300)
 ;; Temporal reasoning.
 

--- a/tests/TQG36.kif.tq
+++ b/tests/TQG36.kif.tq
@@ -1,4 +1,5 @@
 (note TQG36)  ;; boolean version
+(category general)
 (time 1200)
 
 ;; Temporal reasoning.

--- a/tests/TQG37.kif.tq
+++ b/tests/TQG37.kif.tq
@@ -1,4 +1,5 @@
 (note TQG37)  ;; boolean version
+(category general)
 
 ;; Temporal reasoning.
 

--- a/tests/TQG38.kif.tq
+++ b/tests/TQG38.kif.tq
@@ -1,4 +1,5 @@
 (note TQG38)  ;; boolean version
+(category general)
 
 (time 120)
 ;; needs more than 60 sec with Merge and TFF, although only 30 sec with TPTP

--- a/tests/TQG39.kif.tq
+++ b/tests/TQG39.kif.tq
@@ -1,5 +1,6 @@
 (note TQG39)  ;; boolean version
-
+(category general)
+(regen yes)
 ;; Predicate introduction.
 
 (instance transitiveTestPred39-1 BinaryPredicate)

--- a/tests/TQG3_a.kif.tq
+++ b/tests/TQG3_a.kif.tq
@@ -1,0 +1,15 @@
+(note TQG3_DIRECT)
+(category general)
+
+(instance Number3-1 NonnegativeRealNumber)
+
+(=>
+  (instance ?N NonnegativeRealNumber)
+  (not
+    (instance ?N NegativeRealNumber)))
+
+(query
+  (not
+    (instance Number3-1 NegativeRealNumber)))
+
+(answer yes)

--- a/tests/TQG3_b.kif.tq
+++ b/tests/TQG3_b.kif.tq
@@ -1,0 +1,12 @@
+(note TQG3_DISJOINT)
+(category general)
+
+(instance Number3-1 NonnegativeRealNumber)
+
+(disjoint NonnegativeRealNumber NegativeRealNumber)
+
+(query
+  (not
+    (instance Number3-1 NegativeRealNumber)))
+
+(answer yes)

--- a/tests/TQG3_c.kif.tq
+++ b/tests/TQG3_c.kif.tq
@@ -1,0 +1,19 @@
+(note TQG3_DISJOINT_LOCAL_RULE)
+(category general)
+
+(instance Number3-1 NonnegativeRealNumber)
+
+(disjoint NonnegativeRealNumber NegativeRealNumber)
+
+(=>
+  (and
+    (disjoint ?C1 ?C2)
+    (instance ?X ?C1))
+  (not
+    (instance ?X ?C2)))
+
+(query
+  (not
+    (instance Number3-1 NegativeRealNumber)))
+
+(answer yes)

--- a/tests/TQG3_d.kif.tq
+++ b/tests/TQG3_d.kif.tq
@@ -1,0 +1,26 @@
+(note TQG3_SIGNUM_MINIMAL)
+(category general)
+
+(instance Number3-1 NonnegativeRealNumber)
+
+(=>
+  (instance ?X NonnegativeRealNumber)
+  (or
+    (equal (SignumFn ?X) 0)
+    (equal (SignumFn ?X) 1)))
+
+(=>
+  (instance ?X NegativeRealNumber)
+  (equal (SignumFn ?X) -1))
+
+(not
+  (equal -1 0))
+
+(not
+  (equal -1 1))
+
+(query
+  (not
+    (instance Number3-1 NegativeRealNumber)))
+
+(answer yes)

--- a/tests/TQG3_e.kif.tq
+++ b/tests/TQG3_e.kif.tq
@@ -1,0 +1,23 @@
+(note TQG3_DISJOINT_LOCAL_RULE_TYPED)
+(category general)
+
+(instance NonnegativeRealNumber Class)
+(instance NegativeRealNumber Class)
+(instance Number3-1 Entity)
+
+(instance Number3-1 NonnegativeRealNumber)
+
+(disjoint NonnegativeRealNumber NegativeRealNumber)
+
+(=>
+  (and
+    (disjoint ?C1 ?C2)
+    (instance ?X ?C1))
+  (not
+    (instance ?X ?C2)))
+
+(query
+  (not
+    (instance Number3-1 NegativeRealNumber)))
+
+(answer yes)

--- a/tests/TQG4.kif.tq
+++ b/tests/TQG4.kif.tq
@@ -1,6 +1,7 @@
 (note TQG4)  ;; boolean version
 
 (time 600)
+(category general)
 
 (instance Entity4-1 Human)
 

--- a/tests/TQG4.kif.tq
+++ b/tests/TQG4.kif.tq
@@ -1,5 +1,5 @@
 (note TQG4)  ;; boolean version
-
+(minLang thf)
 (time 600)
 (category general)
 

--- a/tests/TQG40.kif.tq
+++ b/tests/TQG40.kif.tq
@@ -1,4 +1,5 @@
 (note TQG40)  ;; boolean version
+(category general)
 
 ;; Predicate introduction.
 

--- a/tests/TQG41.kif.tq
+++ b/tests/TQG41.kif.tq
@@ -1,4 +1,5 @@
 (note TQG41)  ;; boolean version
+(category general)
 
 ;; Predicate introduction.
 

--- a/tests/TQG42.kif.tq
+++ b/tests/TQG42.kif.tq
@@ -1,4 +1,5 @@
 (note TQG42)  ;; boolean version
+(category general)
 
 ;; Predicate introduction.
 

--- a/tests/TQG43.kif.tq
+++ b/tests/TQG43.kif.tq
@@ -1,4 +1,5 @@
 (note TQG43)  ;; boolean version
+(category general)
 
 ;; Predicate introduction.
 

--- a/tests/TQG44.kif.tq
+++ b/tests/TQG44.kif.tq
@@ -1,4 +1,5 @@
 (note TQG44)  ;; boolean version
+(category general)
 
 ;; Predicate introduction.
 

--- a/tests/TQG45.kif.tq
+++ b/tests/TQG45.kif.tq
@@ -1,4 +1,5 @@
 (note TQG45)  ;; boolean version
+(category general)
 (time 300)
 
 ;; Division by 0: The underlying code that implements DivisionFn

--- a/tests/TQG46.kif.tq
+++ b/tests/TQG46.kif.tq
@@ -1,4 +1,5 @@
 (note TQG46)  ;; boolean version
+(category general)
 
 ;; Row variable expansion.
 

--- a/tests/TQG47.kif.tq
+++ b/tests/TQG47.kif.tq
@@ -1,4 +1,5 @@
 (note TQG47)  ;; boolean version
+(category general)
 
 ;; Row variable expansion.
 

--- a/tests/TQG48.kif.tq
+++ b/tests/TQG48.kif.tq
@@ -1,4 +1,5 @@
 (note TQG48)  ;; boolean version
+(category general)
 
 ;; Row variable expansion.
 

--- a/tests/TQG49.kif.tq
+++ b/tests/TQG49.kif.tq
@@ -1,4 +1,5 @@
 (note TQG49)  ;; boolean version
+(category general)
 
 ;; Row variable expansion.
 

--- a/tests/TQG5.kif.tq
+++ b/tests/TQG5.kif.tq
@@ -1,4 +1,5 @@
 (note TQG5)  ;; boolean version
+(category general)
 
 (time 300)
 

--- a/tests/TQG50.kif.tq
+++ b/tests/TQG50.kif.tq
@@ -1,4 +1,5 @@
 (note TQG50)  ;; boolean version
+(category general)
 
 ;; Skolemization of a deep class hierarchy, with subsumption.
 

--- a/tests/TQG51.kif.tq
+++ b/tests/TQG51.kif.tq
@@ -1,5 +1,6 @@
 (note TQG51)
-
+(category general)
+(minLang tff)
 (time 300)
 
 (domain maximumPayloadCapacity 1 Vehicle)	;; in MilitaryDevices	
@@ -23,7 +24,3 @@
 (query (maximumPayloadCapacity Robot1 (MeasureFn ?Y TonMass))) 
 
 (answer 0.0453515)
-
-
-
-

--- a/tests/TQG51b.kif.tq
+++ b/tests/TQG51b.kif.tq
@@ -1,5 +1,7 @@
 (note TQG51b-notWorking)
+(category general)
 
+(minLang tff)
 (time 300)
 
 (domain maximumPayloadCapacity 1 Vehicle)	;; in MilitaryDevices	

--- a/tests/TQG52.kif.tq
+++ b/tests/TQG52.kif.tq
@@ -1,5 +1,7 @@
 (note TQG52)
+(category general)
 
+(minLang tff)
 (time 300)
 
 (=>
@@ -22,11 +24,7 @@
 
 (query
   (and
-    (measure MyCar (MeasureFn ?X PoundMass)))
-    (greaterThan ?X ?Y))
+    (measure MyCar (MeasureFn ?X PoundMass))
+    (greaterThan ?X ?Y)))
 
 (answer no)
-
-
-
-

--- a/tests/TQG6.kif.tq
+++ b/tests/TQG6.kif.tq
@@ -1,4 +1,5 @@
 (note TQG6)  ;; boolean version
+(category general)
 
 (time 60)
 

--- a/tests/TQG7.kif.tq
+++ b/tests/TQG7.kif.tq
@@ -1,4 +1,5 @@
 (note TQG7)  ;; boolean version
+(category general)
 
 (instance Bill7-1 Man)
 (instance Jane7-1 Woman)

--- a/tests/TQG8.kif.tq
+++ b/tests/TQG8.kif.tq
@@ -1,4 +1,5 @@
 (note TQG8)  ;; boolean version
+(category general)
 
 (time 900)
 

--- a/tests/TQG9.kif.tq
+++ b/tests/TQG9.kif.tq
@@ -1,4 +1,5 @@
 (note TQG9)  ;; boolean version
+(category general)
 
 ;; Class identification.
 

--- a/tests/TQM10.kif.tq
+++ b/tests/TQM10.kif.tq
@@ -2,15 +2,21 @@
 
 ; content from SUMO - needed when using tinySUMO
 
+(minLang thf)
+(category modal)
+
 (instance employs BinaryPredicate)
 (domain employs 1 AutonomousAgent)
-(domain employs 2 Human)
+(domain employs 2 Organization)
 (instance subOrganization BinaryPredicate)
 (domain subOrganization 1 Organization)
 (domain subOrganization 2 Organization)
 (instance suffers BinaryPredicate)
 (domain suffers 1 Process)
 (domain suffers 2 AutonomousAgent)
+(instance WhenFn UnaryFunction)
+(domain WhenFn 1 Physical)
+(range WhenFn TimeInterval)
 (instance PastFn UnaryFunction)
 (domain PastFn 1 TimePosition)
 (range PastFn TimeInterval)
@@ -21,7 +27,7 @@
 (domain GovernmentFn 1 GeographicArea)
 (range GovernmentFn Organization)
 (subclass Entering Process)
-(subclass April TimeInteral)
+(subclass April TimeInterval)
 (instance DayFn BinaryFunction)
 (domain DayFn 1 Integer)
 (domain DayFn 2 TimeInterval)
@@ -30,8 +36,8 @@
 (domainSubclass MonthFn 1 TimeInterval)
 (domain MonthFn 2 TimeInterval)
 (range MonthFn TimeInterval)
-(instance YearFn BinaryFunction)
-(domainSubclass YearFn 1 Integer)
+(instance YearFn UnaryFunction)
+(domain YearFn 1 Integer)
 (range YearFn TimeInterval)
 (instance plaintiff BinaryPredicate)
 (domain plaintiff 1 Process)
@@ -55,13 +61,14 @@
 ;       (whenFn @ E @ W) @
 ;       (dayFn @ n1 @ (monthFn @ april @ (yearFn @ n2025)))))))).
       
-(and
-  (instance ?E Entering) 
-  (agent ?E AgentSmith) 
-  (destination ?E Area51) 
-  (during 
-    (WhenFn ?E ?W) 
-    (DayFn 1 (MonthFn April (YearFn 2025)))))
+(exists (?E)
+  (and
+    (instance ?E Entering) 
+    (agent ?E AgentSmith) 
+    (destination ?E Area51) 
+    (during 
+      (WhenFn ?E) 
+      (DayFn 1 (MonthFn April (YearFn 2025))))))
              
 ; Agent Smith works for the MIB unit.
 
@@ -117,12 +124,12 @@
 (=>
   (employs ?EMP USGovernment)
   (confersObligation USGovernment ?EMP
-    (exists (?E)
-      (and
-        (instance ?E Entering) 
-        (agent ?E ?EMP) 
-        (destination ?E Area51)))))
-             
+    (not
+      (exists (?E)
+        (and
+          (instance ?E Entering) 
+          (agent ?E ?EMP) 
+          (destination ?E Area51))))))
 
 ; Agents that violate their obligations have a US government disciplinary hearing.
 
@@ -237,7 +244,6 @@
   (holdsDuring ?T 
     (employs ?SUPER ?A)))
              
-    
 ; Does Agent Smith work for the MIB unit in July 2025?
 
 ;thf(conj,conjecture,
@@ -265,6 +271,7 @@
 ;     (suffers @ D @ agentSmith @ cw)))).
           
 ; query: 
-; (exists (?D) (and (instance ?D TerminatingEmployment) (suffers ?D AgentSmith)))
+(query (exists (?D) (and (instance ?D TerminatingEmployment) (suffers ?D AgentSmith))))
 ; thf(conj,conjecture,(?[D:$i]:((s__instance @ D @ s__TerminatingEmployment) & (s__suffers @ D @ s__AgentSmith @ cw)))).
 
+(answer yes)

--- a/tests/TQM3.kif.tq
+++ b/tests/TQM3.kif.tq
@@ -1,5 +1,7 @@
 (note TQM3)
 (time 20)
+(minLang thf)
+(category modal)
 (file tinySUMO.kif)
 (file tinyHOL.kif)
 
@@ -24,7 +26,7 @@
     (located ?C ?E)
     (attribute ?E Flat)
     (agent ?C ?A))
-  (attribute ?A Dead)))
+  (attribute ?A Dead))
      
 ; We want to say if (X => Y) and A believes X then A believes Y - requires true HOL
 
@@ -44,3 +46,9 @@
        
 ; (believes Bill
 ;   (attribute ?P Dead))
+
+(query
+  (believes Bill
+    (attribute Joe Dead)))
+
+(answer yes)

--- a/tests/TQROW-BUILTIN.kif.tq
+++ b/tests/TQROW-BUILTIN.kif.tq
@@ -1,0 +1,15 @@
+(note TQROW-BUILTIN)
+(category general)
+
+(partition ParentClass ChildA ChildB ChildC)
+
+(=>
+  (partition ?C @ROW)
+  (equal (ChildrenOfFn ?C) (ListFn @ROW)))
+
+(query
+  (equal
+    (ChildrenOfFn ParentClass)
+    (ListFn ChildA ChildB ChildC)))
+
+(answer yes)

--- a/tests/TQROW_fixedArity.kif.tq
+++ b/tests/TQROW_fixedArity.kif.tq
@@ -1,0 +1,19 @@
+(note TQROW_FIXED_ARITY)
+(category general)
+
+(instance testRowPred Predicate)
+
+(instance A Entity)
+(instance B Entity)
+(instance C Entity)
+
+(testRowPred A B C)
+
+(=>
+  (testRowPred ?X ?Y ?Z)
+  (equal (ListFn ?X ?Y ?Z) TestList))
+
+(query
+  (equal (ListFn A B C) TestList))
+
+(answer yes)

--- a/tests/TQROW_listFn.kif.tq
+++ b/tests/TQROW_listFn.kif.tq
@@ -1,0 +1,23 @@
+(note TQROW_LISTFN)
+(category general)
+
+(instance testRowPred Predicate)
+(instance testRowPred VariableArityRelation)
+(domain testRowPred 1 Entity)
+(domain testRowPred 2 Entity)
+(domain testRowPred 3 Entity)
+
+(instance A Entity)
+(instance B Entity)
+(instance C Entity)
+
+(testRowPred A B C)
+
+(=>
+  (testRowPred @ROW)
+  (inList B (ListFn @ROW)))
+
+(query
+  (inList B (ListFn A B C)))
+
+(answer yes)

--- a/tests/TQROW_noDomain.kif.tq
+++ b/tests/TQROW_noDomain.kif.tq
@@ -1,0 +1,20 @@
+(note TQROW_NO_DOMAIN)
+(category general)
+
+(instance testRowPred Predicate)
+(instance testRowPred VariableArityRelation)
+
+(instance A Entity)
+(instance B Entity)
+(instance C Entity)
+
+(testRowPred A B C)
+
+(=>
+  (testRowPred @ROW)
+  (equal (ListFn @ROW) TestList))
+
+(query
+  (equal (ListFn A B C) TestList))
+
+(answer yes)

--- a/tests/TQROW_withDomain.kif.tq
+++ b/tests/TQROW_withDomain.kif.tq
@@ -1,0 +1,23 @@
+(note TQROW_WITH_DOMAIN)
+(category general)
+
+(instance testRowPred Predicate)
+(instance testRowPred VariableArityRelation)
+(domain testRowPred 1 Entity)
+(domain testRowPred 2 Entity)
+(domain testRowPred 3 Entity)
+
+(instance A Entity)
+(instance B Entity)
+(instance C Entity)
+
+(testRowPred A B C)
+
+(=>
+  (testRowPred @ROW)
+  (equal (ListFn @ROW) TestList))
+
+(query
+  (equal (ListFn A B C) TestList))
+
+(answer yes)

--- a/tests/listTest1.kif.tq
+++ b/tests/listTest1.kif.tq
@@ -1,0 +1,7 @@
+(note TQLIST1)
+(category general)
+
+(query
+  (instance (ListFn A B C) List))
+
+(answer yes)

--- a/tests/listTest2.kif.tq
+++ b/tests/listTest2.kif.tq
@@ -1,0 +1,9 @@
+(note TQLIST2)
+(category general)
+
+(query
+  (equal
+    (ListOrderFn (ListFn A B C) 2)
+    B))
+
+(answer yes)

--- a/tests/listTest3.kif.tq
+++ b/tests/listTest3.kif.tq
@@ -1,0 +1,7 @@
+(note TQLIST3)
+(category general)
+
+(query
+  (inList B (ListFn A B C)))
+
+(answer yes)

--- a/tests/partitionTest1.kif.tq
+++ b/tests/partitionTest1.kif.tq
@@ -1,0 +1,19 @@
+(note TQPARTROW1)
+(category general)
+
+(instance ChildrenOfFn UnaryFunction)
+(domain ChildrenOfFn 1 Class)
+(range ChildrenOfFn List)
+
+(partition ParentClass ChildA ChildB ChildC)
+
+(=>
+  (partition ?C @ROW)
+  (equal (ChildrenOfFn ?C) (ListFn @ROW)))
+
+(query
+  (equal
+    (ChildrenOfFn ParentClass)
+    (ListFn ChildA ChildB ChildC)))
+
+(answer yes)

--- a/tests/partitionTest2.kif.tq
+++ b/tests/partitionTest2.kif.tq
@@ -1,0 +1,23 @@
+(note TQPARTROW2)
+(category general)
+
+(partition Organism25-Test Animal Plant Fungus Microorganism)
+
+(instance Obj25-Test Organism25-Test)
+(not (instance Obj25-Test Animal))
+(not (instance Obj25-Test Fungus))
+(not (instance Obj25-Test Microorganism))
+
+(=>
+  (and
+    (partition ?C @ROW)
+    (instance ?X ?C))
+  (exists (?SUBCLASS)
+    (and
+      (inList ?SUBCLASS (ListFn @ROW))
+      (instance ?X ?SUBCLASS))))
+
+(query
+  (instance Obj25-Test Plant))
+
+(answer yes)

--- a/tests/rowVarTest1.kif.tq
+++ b/tests/rowVarTest1.kif.tq
@@ -1,0 +1,23 @@
+(note TQROW1)
+(category general)
+
+(instance testRowPred Predicate)
+(instance testRowPred VariableArityRelation)
+(domain testRowPred 1 Entity)
+(domain testRowPred 2 Entity)
+(domain testRowPred 3 Entity)
+
+(instance A Entity)
+(instance B Entity)
+(instance C Entity)
+
+(testRowPred A B C)
+
+(=>
+  (testRowPred @ROW)
+  (equal (ListFn @ROW) TestList))
+
+(query
+  (equal (ListFn A B C) TestList))
+
+(answer yes)


### PR DESCRIPTION
* Added and updated inference tests for numbers, arithmetic, lists, partitions, and row-variable expansion.
* Added categories, timeouts, regeneration flags, and `minLang` settings across SUMO test files.
* Added `holUseModals` metadata for modal tests that require HOL modal translation.
* Fixed and simplified several TQ test queries, answers, and assertions.
* Added tests for `ListFn`, `ListOrderFn`, `partition`, `contraryAttribute`, and `SignumFn`.
