### PR TITLE
Introduce Cyber.kif with Vulnerability and vulnerableSystem

### DIFF
--- a/development/Cyber.kif
+++ b/development/Cyber.kif
@@ -1,0 +1,75 @@
+;;Cyber.kif - cybersecurity domain ontology
+;;
+;; Initial introduction with two foundational terms: Vulnerability and
+;; vulnerableSystem. Every claim in each term's documentation string is
+;; backed by at least one axiom in this file.
+
+;; ============================================================
+;; Vulnerability (RelationalAttribute)
+;; ============================================================
+
+(subclass Vulnerability RelationalAttribute)
+(termFormat EnglishLanguage Vulnerability "vulnerability")
+(documentation Vulnerability EnglishLanguage "A &%RelationalAttribute of a
+&%Physical entity (typically a &%ComputerNetwork, &%Computer, or
+&%ComputerProgram) indicating a weakness exploitable by some
+&%AutonomousAgent. Vulnerability is relational because the same flaw on the
+same system may be exploitable by one agent without being exploitable by
+another, formalized through the agent argument of &%vulnerableSystem.
+Vulnerabilities are latent: an instance may exist on a system whether or
+not any agent has discovered it.")
+
+(=>
+  (and
+    (instance ?VUL Vulnerability)
+    (attribute ?SYS ?VUL))
+  (exists (?AGENT)
+    (and
+      (instance ?AGENT AutonomousAgent)
+      (vulnerableSystem ?VUL ?SYS ?AGENT))))
+
+(exists (?VUL ?SYS ?A1 ?A2)
+  (and
+    (instance ?VUL Vulnerability)
+    (instance ?SYS Physical)
+    (instance ?A1 AutonomousAgent)
+    (instance ?A2 AutonomousAgent)
+    (not (equal ?A1 ?A2))
+    (vulnerableSystem ?VUL ?SYS ?A1)
+    (not (vulnerableSystem ?VUL ?SYS ?A2))))
+
+(exists (?VUL ?SYS)
+  (and
+    (instance ?VUL Vulnerability)
+    (attribute ?SYS ?VUL)
+    (not
+      (exists (?AGENT)
+        (and
+          (instance ?AGENT AutonomousAgent)
+          (knows ?AGENT
+            (attribute ?SYS ?VUL)))))))
+
+;; ============================================================
+;; vulnerableSystem (TernaryPredicate)
+;; ============================================================
+
+(instance vulnerableSystem TernaryPredicate)
+(domain vulnerableSystem 1 Vulnerability)
+(domain vulnerableSystem 2 Physical)
+(domain vulnerableSystem 3 AutonomousAgent)
+(termFormat EnglishLanguage vulnerableSystem "vulnerable system")
+(format EnglishLanguage vulnerableSystem "%2 is vulnerable to %1 from the perspective of %3")
+(documentation vulnerableSystem EnglishLanguage "(&%vulnerableSystem ?VUL
+?SYSTEM ?AGENT) means that ?SYSTEM bears the &%Vulnerability ?VUL and ?VUL
+is exploitable on ?SYSTEM by ?AGENT given the agent's available resources.
+The agent argument is what makes &%Vulnerability relational: the same flaw
+on the same system may stand in &%vulnerableSystem to one agent without
+standing in &%vulnerableSystem to another.")
+
+(=>
+  (and
+    (instance ?VUL Vulnerability)
+    (instance ?SYS Physical)
+    (instance ?AGENT AutonomousAgent)
+    (vulnerableSystem ?VUL ?SYS ?AGENT))
+  (attribute ?SYS ?VUL))


### PR DESCRIPTION
Seeds development/Cyber.kif with two foundational cybersecurity domain terms. Every factual claim in each term's documentation string is backed by at least one formal axiom in the file, per the pipeline convention that a term is not coded to completion until its documentation is fully formalized.

Vulnerability is a RelationalAttribute of a Physical entity indicating a weakness exploitable by some AutonomousAgent. Three axioms drive out the doc-string claims. An exploitability witness states that any system carrying a Vulnerability stands in vulnerableSystem to some agent, capturing the doc-string claim that a Vulnerability is exploitable by some agent. An agent-relativity witness states that a Vulnerability may hold in vulnerableSystem for one agent without holding for another distinct agent on the same system, capturing the doc-string claim that the same flaw may be exploitable by one agent without being exploitable by another. A latency witness states that a Vulnerability may exist on a system with no AutonomousAgent standing in the knows relation to that attribute, capturing the doc-string claim that vulnerabilities are latent.

vulnerableSystem is a TernaryPredicate over Vulnerability, Physical, and AutonomousAgent. Its agent argument is what makes Vulnerability a relational rather than intrinsic attribute. A bearer-attribute rule derives that if vulnerableSystem holds, the system carries the Vulnerability as an attribute, so any consumer that queries the system's attributes finds the vulnerability without needing to unpack the ternary relation.

KifFileChecker via sigma-fullcheck.sh reports zero errors or warnings on Cyber.kif under the current SUMO KB constituent set.

Subsequent Cyber.kif work (SoftwareBug family, bug-vulnerability bridge, Adversarial Knapsack terms, exploit and patch cost predicates) will land as separate PRs.