### PR TITLE
Add exploitCost and patchCost to Cyber.kif

### DIFF
--- a/development/Cyber.kif
+++ b/development/Cyber.kif
@@ -364,3 +364,114 @@ from arXiv:2403.10789.")
     (operationalBudget ?A1 ?B1)
     (operationalBudget ?A2 ?B2)
     (not (equal ?B1 ?B2))))
+;; ============================================================
+;; exploitCost (TernaryPredicate)
+;; ============================================================
+
+(instance exploitCost TernaryPredicate)
+(instance exploitCost SingleValuedRelation)
+(domain exploitCost 1 Vulnerability)
+(domain exploitCost 2 AutonomousAgent)
+(domain exploitCost 3 CurrencyMeasure)
+(termFormat EnglishLanguage exploitCost "exploit cost")
+(format EnglishLanguage exploitCost "exploiting %1 costs %2 an amount of %3")
+(documentation exploitCost EnglishLanguage "(&%exploitCost ?VUL ?AGENT
+?COST) means that it costs ?AGENT an amount of ?COST to exploit
+&%Vulnerability ?VUL. Encompasses tooling acquisition, scaling effort,
+compute resources, expertise, and operational overhead. Agent-relative:
+different agents may face different exploit costs for the same
+vulnerability depending on prior tooling and capability. Common
+knowledge: both the attacker for whom the vulnerability is exploitable
+and any defender possessing the vulnerable system know the exploit
+cost. Single-valued: for a given vulnerability and agent there is at
+most one exploit cost.")
+
+(=>
+  (and
+    (instance ?VUL Vulnerability)
+    (instance ?AGENT AutonomousAgent)
+    (exploitCost ?VUL ?AGENT ?COST)
+    (measure ?COST ?AMOUNT))
+  (greaterThanOrEqualTo ?AMOUNT 0))
+
+(=>
+  (and
+    (instance ?SYS Physical)
+    (vulnerableSystem ?VUL ?SYS ?AGENT))
+  (exists (?COST)
+    (exploitCost ?VUL ?AGENT ?COST)))
+
+(=>
+  (and
+    (vulnerableSystem ?VUL ?SYS ?ATTACKER)
+    (possesses ?DEFENDER ?SYS)
+    (exploitCost ?VUL ?ATTACKER ?COST))
+  (and
+    (knows ?ATTACKER (exploitCost ?VUL ?ATTACKER ?COST))
+    (knows ?DEFENDER (exploitCost ?VUL ?ATTACKER ?COST))))
+
+(exists (?VUL ?A1 ?A2 ?C1 ?C2)
+  (and
+    (instance ?VUL Vulnerability)
+    (instance ?A1 AutonomousAgent)
+    (instance ?A2 AutonomousAgent)
+    (not (equal ?A1 ?A2))
+    (exploitCost ?VUL ?A1 ?C1)
+    (exploitCost ?VUL ?A2 ?C2)
+    (not (equal ?C1 ?C2))))
+
+;; ============================================================
+;; patchCost (TernaryPredicate)
+;; ============================================================
+
+(instance patchCost TernaryPredicate)
+(instance patchCost SingleValuedRelation)
+(domain patchCost 1 Vulnerability)
+(domain patchCost 2 AutonomousAgent)
+(domain patchCost 3 CurrencyMeasure)
+(termFormat EnglishLanguage patchCost "patch cost")
+(format EnglishLanguage patchCost "patching %1 costs %2 an amount of %3")
+(documentation patchCost EnglishLanguage "(&%patchCost ?VUL ?AGENT ?COST)
+means that it costs ?AGENT an amount of ?COST to patch or remediate
+&%Vulnerability ?VUL. Includes development, testing, deployment, and any
+operational disruption overhead. Agent-relative: an organization with
+mature patch management pays less than one building remediation
+capability from scratch. Common knowledge: both the attacker for whom
+the vulnerability is exploitable and the defender possessing the
+vulnerable system know the patch cost. Single-valued: for a given
+vulnerability and agent there is at most one patch cost.")
+
+(=>
+  (and
+    (instance ?VUL Vulnerability)
+    (instance ?AGENT AutonomousAgent)
+    (patchCost ?VUL ?AGENT ?COST)
+    (measure ?COST ?AMOUNT))
+  (greaterThanOrEqualTo ?AMOUNT 0))
+
+(=>
+  (and
+    (instance ?ATTACKER AutonomousAgent)
+    (vulnerableSystem ?VUL ?SYS ?ATTACKER)
+    (possesses ?DEFENDER ?SYS))
+  (exists (?COST)
+    (patchCost ?VUL ?DEFENDER ?COST)))
+
+(=>
+  (and
+    (vulnerableSystem ?VUL ?SYS ?ATTACKER)
+    (possesses ?DEFENDER ?SYS)
+    (patchCost ?VUL ?DEFENDER ?COST))
+  (and
+    (knows ?ATTACKER (patchCost ?VUL ?DEFENDER ?COST))
+    (knows ?DEFENDER (patchCost ?VUL ?DEFENDER ?COST))))
+
+(exists (?VUL ?A1 ?A2 ?C1 ?C2)
+  (and
+    (instance ?VUL Vulnerability)
+    (instance ?A1 AutonomousAgent)
+    (instance ?A2 AutonomousAgent)
+    (not (equal ?A1 ?A2))
+    (patchCost ?VUL ?A1 ?C1)
+    (patchCost ?VUL ?A2 ?C2)
+    (not (equal ?C1 ?C2))))


### PR DESCRIPTION
Introduces exploitCost and patchCost as agent-relative ternary predicates for the adversarial-knapsack framing of cybersecurity strategy.

exploitCost relates a Vulnerability, an AutonomousAgent, and a CurrencyMeasure representing the cost that agent bears to exploit the vulnerability. patchCost mirrors the same shape for remediation cost. Both are declared SingleValuedRelation since for a given vulnerability and agent there is at most one cost.

Non-negativity is enforced by rules requiring that any cost value's numeric measure is greater than or equal to zero. Agent-relativity is asserted by existential witnesses showing that the same vulnerability can carry different exploit or patch costs for two different agents.

The common-information property from the game-theoretic frame is captured by axioms tying both predicates to vulnerableSystem and possesses. When a vulnerability is exploitable on a system by an attacker and a defender possesses that system, both agents know the exploit cost and both agents know the defender's patch cost. Existence axioms further assert that any exploitable vulnerability has a defined exploit cost for its exploiting agent, and any defender of a vulnerable system has a defined patch cost for that vulnerability.

A follow-up will decompose each predicate into fixed tooling and per-instance scaling terms.