### PR TITLE
Add violatedKnapsack attribute and knapsack constraint rule to Cyber.kif

### DIFF
--- a/development/Cyber.kif
+++ b/development/Cyber.kif
@@ -264,3 +264,60 @@ cost.")
     (aggregateCyberCost ?AGENT ?T1 ?TOT1)
     (aggregateCyberCost ?AGENT ?T2 ?TOT2)
     (not (equal ?TOT1 ?TOT2))))
+
+;; ============================================================
+;; violatedKnapsack (RelationalAttribute)
+;; ============================================================
+
+(instance violatedKnapsack RelationalAttribute)
+(termFormat EnglishLanguage violatedKnapsack "violated knapsack")
+(documentation violatedKnapsack EnglishLanguage "An &%Attribute of an
+&%AutonomousAgent that holds during a &%TimeInterval when the agent's
+&%aggregateCyberCost for that interval exceeds their
+&%operationalBudget. Agent-relative: within the same interval one
+agent may violate while another satisfies. Interval-relative: the
+same agent may satisfy in one interval and violate in another.")
+
+(=>
+  (and
+    (instance ?AGENT AutonomousAgent)
+    (instance ?T TimeInterval)
+    (operationalBudget ?AGENT ?BUDGET)
+    (aggregateCyberCost ?AGENT ?T ?TOTAL)
+    (measure ?BUDGET ?BUDGET_AMOUNT)
+    (measure ?TOTAL ?TOTAL_AMOUNT)
+    (greaterThan ?TOTAL_AMOUNT ?BUDGET_AMOUNT))
+  (holdsDuring ?T
+    (attribute ?AGENT violatedKnapsack)))
+
+(exists (?A1 ?A2 ?T ?B1 ?B2 ?TOT1 ?TOT2 ?BA1 ?BA2 ?TA1 ?TA2)
+  (and
+    (instance ?A1 AutonomousAgent)
+    (instance ?A2 AutonomousAgent)
+    (not (equal ?A1 ?A2))
+    (instance ?T TimeInterval)
+    (operationalBudget ?A1 ?B1)
+    (operationalBudget ?A2 ?B2)
+    (aggregateCyberCost ?A1 ?T ?TOT1)
+    (aggregateCyberCost ?A2 ?T ?TOT2)
+    (measure ?B1 ?BA1)
+    (measure ?B2 ?BA2)
+    (measure ?TOT1 ?TA1)
+    (measure ?TOT2 ?TA2)
+    (greaterThan ?TA1 ?BA1)
+    (not (greaterThan ?TA2 ?BA2))))
+
+(exists (?AGENT ?T1 ?T2 ?B ?TOT1 ?TOT2 ?BA ?TA1 ?TA2)
+  (and
+    (instance ?AGENT AutonomousAgent)
+    (instance ?T1 TimeInterval)
+    (instance ?T2 TimeInterval)
+    (not (equal ?T1 ?T2))
+    (operationalBudget ?AGENT ?B)
+    (aggregateCyberCost ?AGENT ?T1 ?TOT1)
+    (aggregateCyberCost ?AGENT ?T2 ?TOT2)
+    (measure ?B ?BA)
+    (measure ?TOT1 ?TA1)
+    (measure ?TOT2 ?TA2)
+    (not (greaterThan ?TA1 ?BA))
+    (greaterThan ?TA2 ?BA)))


### PR DESCRIPTION
Adds one attribute and one rule to the cybersecurity ontology under development/.

**violatedKnapsack (RelationalAttribute).** An attribute of an AutonomousAgent that holds during a TimeInterval when the agent's aggregateCyberCost for that interval exceeds their operationalBudget. Agent-relative and interval-relative.

**Knapsack constraint rule.** Given operationalBudget(?AGENT, ?BUDGET) and aggregateCyberCost(?AGENT, ?T, ?TOTAL), if the numeric measure of ?TOTAL exceeds the numeric measure of ?BUDGET, then holdsDuring(?T, attribute(?AGENT, violatedKnapsack)). Amounts are compared via measure to accommodate the CurrencyMeasure domain of operationalBudget arg 2 and aggregateCyberCost arg 3.

**Witnesses.** Two existentials, matching the doc string clauses: one shows that within a single interval one agent may bear the attribute while another does not, and one shows that the same agent may satisfy the constraint in one interval and violate it in another.

**Coverage.** Every claim in the documentation string is backed by an axiom in this file.

**Validation.** sigma-fullcheck completed with no errors traceable to the new content. The 2104 errors reported against Cyber.kif line 179 all reference terms (PorousContainer, accreln1, loadBearingRegion, equal__1Re2Re, BeginFn) that appear zero times in Cyber.kif, matching the upstream Sigma line-attribution behavior observed on the two prior Cyber.kif PRs.