### PR TITLE
Add AdversarialKnapsack class and game-frame rules to Cyber.kif

### DIFF
--- a/development/Cyber.kif
+++ b/development/Cyber.kif
@@ -321,3 +321,46 @@ same agent may satisfy in one interval and violate in another.")
     (measure ?TOT2 ?TA2)
     (not (greaterThan ?TA1 ?BA))
     (greaterThan ?TA2 ?BA)))
+
+;; ============================================================
+;; AdversarialKnapsack (subclass of Contest)
+;; ============================================================
+
+(subclass AdversarialKnapsack Contest)
+(termFormat EnglishLanguage AdversarialKnapsack "adversarial knapsack")
+(documentation AdversarialKnapsack EnglishLanguage "A &%Contest between
+&%AutonomousAgents competing under resource constraints. Every
+&%AdversarialKnapsack has at least two distinct participant agents,
+and each participant has an &%operationalBudget bounding the cyber
+actions they can commit to. Formalizes the Adversarial Knapsack game
+from arXiv:2403.10789.")
+
+(=>
+  (instance ?AK AdversarialKnapsack)
+  (exists (?A1 ?A2)
+    (and
+      (instance ?A1 AutonomousAgent)
+      (instance ?A2 AutonomousAgent)
+      (not (equal ?A1 ?A2))
+      (contestParticipant ?AK ?A1)
+      (contestParticipant ?AK ?A2))))
+
+(=>
+  (and
+    (instance ?AK AdversarialKnapsack)
+    (instance ?AGENT AutonomousAgent)
+    (contestParticipant ?AK ?AGENT))
+  (exists (?BUDGET)
+    (operationalBudget ?AGENT ?BUDGET)))
+
+(exists (?AK ?A1 ?A2 ?B1 ?B2)
+  (and
+    (instance ?AK AdversarialKnapsack)
+    (instance ?A1 AutonomousAgent)
+    (instance ?A2 AutonomousAgent)
+    (not (equal ?A1 ?A2))
+    (contestParticipant ?AK ?A1)
+    (contestParticipant ?AK ?A2)
+    (operationalBudget ?A1 ?B1)
+    (operationalBudget ?A2 ?B2)
+    (not (equal ?B1 ?B2))))


### PR DESCRIPTION
Adds one class and its game-frame rules to the cybersecurity ontology under development/.

**AdversarialKnapsack (subclass of Contest).** A Contest between AutonomousAgents competing under resource constraints. Formalizes the Adversarial Knapsack game from arXiv:2403.10789. Scope of this PR is the game frame: participants and their budget hookup. The behavioral content of the game (exploit and patch action selection, zero-sum utility, per-vulnerability cost accounting) is out of scope here and will follow in subsequent Cyber.kif PRs.

**Two-participant structural rule.** Every AdversarialKnapsack has at least two distinct AutonomousAgent participants under contestParticipant.

**Participant-budget hookup.** Every contestParticipant of an AdversarialKnapsack has an operationalBudget. This is the wire from the game frame into the knapsack constraint machinery already in Cyber.kif (violatedKnapsack + aggregateCyberCost > operationalBudget).

**Witness.** An AdversarialKnapsack exists whose two participants have distinct budgets, since the two sides of the game are not required to be symmetric.

**Coverage.** Every claim in the documentation string is backed by an axiom in this file.

**Validation.** sigma-fullcheck reports "No errors found in Cyber.kif". All other errors in the run trace back to unrelated upstream modules (loadBearingRegion, PorousContainer, accreln1 modal encoding) and appear zero times in Cyber.kif.