### PR TITLE
Rename committedDeliveryDuration to committedDeliveryDurationFn in SupplyChain.kif

### DIFF
--- a/development/SupplyChain.kif
+++ b/development/SupplyChain.kif
@@ -416,7 +416,7 @@
   "A &%Process in which an active &%PurchaseOrder for a &%CorpuscularObject cannot
    be fulfilled because the product cannot be replenished within the committed
    delivery &%TimeDuration: its &%leadTimeDuration exceeds, or is unknown within,
-   that window, given by &%committedDeliveryDuration. The unfulfillable product is
+   that window, given by &%committedDeliveryDurationFn. The unfulfillable product is
    the &%patient of the &%BackorderEvent. A &%BackorderEvent is distinct from a
    stockout: a stockout is a property of inventory, whereas a &%BackorderEvent is a
    property of an unfulfilled &%PurchaseOrder.")
@@ -440,15 +440,15 @@
          (not
            (exists (?lt)
              (and (leadTimeDuration ?sku ?lt)
-                  (lessThanOrEqualTo ?lt (committedDeliveryDuration ?B))))))))
+                  (lessThanOrEqualTo ?lt (committedDeliveryDurationFn ?B))))))))
 
-(instance committedDeliveryDuration UnaryFunction)
-(domain committedDeliveryDuration 1 BackorderEvent)
-(range committedDeliveryDuration TimeDuration)
-(termFormat EnglishLanguage committedDeliveryDuration "committed delivery duration")
+(instance committedDeliveryDurationFn UnaryFunction)
+(domain committedDeliveryDurationFn 1 BackorderEvent)
+(range committedDeliveryDurationFn TimeDuration)
+(termFormat EnglishLanguage committedDeliveryDurationFn "committed delivery duration")
 
-(documentation committedDeliveryDuration EnglishLanguage
-  "(&%committedDeliveryDuration ?B) is the &%TimeDuration within which the
+(documentation committedDeliveryDurationFn EnglishLanguage
+  "(&%committedDeliveryDurationFn ?B) is the &%TimeDuration within which the
    &%PurchaseOrder underlying the &%BackorderEvent ?B was committed to be fulfilled,
    measured in &%DayDuration units. It is a &%PositiveRealNumber of days.")
 
@@ -456,7 +456,7 @@
   (instance ?B BackorderEvent)
   (exists (?n)
     (and (instance ?n PositiveRealNumber)
-         (equal (committedDeliveryDuration ?B) (MeasureFn ?n DayDuration)))))
+         (equal (committedDeliveryDurationFn ?B) (MeasureFn ?n DayDuration)))))
 
 (instance localBackorderQuantity BinaryRelation)
 (domain localBackorderQuantity 1 CorpuscularObject)


### PR DESCRIPTION
Renames the SupplyChain.kif function `committedDeliveryDuration` to `committedDeliveryDurationFn` so that its uses in rule bodies parse under the SUO-KIF grammar.

The ANTLR grammar (sigmaAntlr/Suokif.g4:21) restricts funterm heads to tokens ending in `Fn`:

    FUNWORD : LETTER WORDCHAR* 'Fn';
    funterm : '(' FUNWORD argument+ ')' ;

Because the term was declared `(instance committedDeliveryDuration UnaryFunction)` without the `Fn` suffix, occurrences of `(committedDeliveryDuration ?B)` in the rule at development/SupplyChain.kif:459 raised a parser error ("missing FUNWORD at 'committedDeliveryDuration'"), which fails the Test Report jUnit run driven by IntegrationTestSuite.

Nine references renamed in one file. No semantic change: the function's domain, range, documentation, and single defining rule are preserved. Paren balance 680/680. KifFileChecker `-C` clean of any new errors relative to master.