### PR TITLE
Add operationalTempo to Cyber.kif

### DIFF
--- a/development/Cyber.kif
+++ b/development/Cyber.kif
@@ -387,6 +387,39 @@ same agent may satisfy in one interval and violate in another.")
     (greaterThan ?TA2 ?BA)))
 
 ;; ============================================================
+;; operationalTempo (TernaryPredicate)
+;; ============================================================
+
+(instance operationalTempo TernaryPredicate)
+(domain operationalTempo 1 AutonomousAgent)
+(domain operationalTempo 2 RealNumber)
+(domain operationalTempo 3 TimeInterval)
+(termFormat EnglishLanguage operationalTempo "operational tempo")
+(format EnglishLanguage operationalTempo "%1 operates at a tempo factor of %2 during %3")
+(documentation operationalTempo EnglishLanguage "(&%operationalTempo
+?AGENT ?FACTOR ?T) means that ?AGENT's effective &%operationalBudget
+during &%TimeInterval ?T is modulated by the multiplicative ?FACTOR
+relative to their baseline budget.  A ?FACTOR greater than 1 represents
+an effort surge (e.g. 1.15 for a 15% surge); a ?FACTOR less than 1
+represents an effort back-off.  Adapted from the elastic capacity
+modulation parameter beta in Goohs, Dykstra, Melaragno, and Casey,
+'A Game Theory for Resource-Constrained Tactical Cyber Operations,'
+MILCOM 2024, where a surge is modeled as (1+beta)C, a multiplicative
+adjustment to the baseline capacity C.")
+
+(=>
+  (and
+    (instance ?AGENT AutonomousAgent)
+    (instance ?T TimeInterval)
+    (instance ?T ?PERIOD)
+    (operationalTempo ?AGENT ?FACTOR ?T)
+    (operationalBudget ?AGENT ?BASELINE)
+    (measure ?BASELINE ?BASEAMOUNT)
+    (operationalBudgetInPeriod ?AGENT ?PERIODBUDGET ?PERIOD)
+    (measure ?PERIODBUDGET ?PERIODAMOUNT))
+  (equal ?PERIODAMOUNT (MultiplicationFn ?FACTOR ?BASEAMOUNT)))
+
+;; ============================================================
 ;; AdversarialKnapsack (subclass of Contest)
 ;; ============================================================
 


### PR DESCRIPTION
Adds operationalTempo: a multiplicative modulation on an agent's operationalBudget for a given interval, factor >1 is a surge, <1 is a back-off. Pulled from the beta parameter in our MILCOM 2024 knapsack paper (Goohs, Dykstra, Melaragno, Casey), where a surge is (1+beta)C on the baseline capacity C.

Ties into operationalBudgetInPeriod the same way that term already relates to operationalBudget.