### PR TITLE
Update Merge.kif

### DIFF
--- a/Merge.kif
+++ b/Merge.kif
@@ -7837,12 +7837,12 @@ an &%Object.")
     (instance ?SHAPE ShapeAttribute))
   (shape ?OBJ ?SHAPE))
 
-(instance Oval ClosedTwoDimensionalFigure)
+(subclass Oval ClosedTwoDimensionalFigure)
 
 (documentation Oval EnglishLanguage "An instance of &%ClosedTwoDimensionalFigures that is
 produced by the intersection of a &%Cone with a &%ClosedTwoDimensionalFigure.")
 
-(subAttribute Circle Oval)
+(subclass Circle Oval)
 
 (documentation Circle EnglishLanguage "A &%subAttribute of &%Oval such that all
 &%GeometricPoints that make up the &%Circle are equidistant from a single


### PR DESCRIPTION
Changed "Circle" to be a subclass of Oval, and Oval to be and subclass of a ClosedTwoDimensionalFigure.

Circle is used as a subclass all over the repository, should fix several bugs.