### PR TITLE
Declare loadBearingRegion as a binary predicate

### DIFF
--- a/Objects.kif
+++ b/Objects.kif
@@ -834,6 +834,14 @@
   (modalAttribute
     (material Fabric ?BP) Likely))
 
+(instance loadBearingRegion BinaryPredicate)
+(domain loadBearingRegion 1 Backpack)
+(domain loadBearingRegion 2 HumanBack)
+(termFormat EnglishLanguage loadBearingRegion "load bearing region")
+(documentation loadBearingRegion EnglishLanguage "(&%loadBearingRegion ?BP
+?REGION) means that ?REGION is the part of the wearer's &%HumanBack that
+bears the weight of ?BP while it is worn.")
+
 (=>
   (and
     (instance ?BP Backpack)


### PR DESCRIPTION
loadBearingRegion is used in two rules in Objects.kif (lines 850, 859) but was never declared anywhere in the file -- no instance/domain/documentation. Adds the missing declaration: a BinaryPredicate over Backpack and HumanBack, matching how the two existing rules already use it.

Undeclared, it falls back to a generic individual-constant type in downstream TPTP/THF translation, and applying an individual-typed constant to arguments produces malformed output for any tool consuming the translated form.