### PR TITLE
Fix parse-breaking semicolon in SecurityControl documentation string

### DIFF
--- a/development/Cyber.kif
+++ b/development/Cyber.kif
@@ -1214,7 +1214,7 @@ mechanism -- an &%Object, a &%Process, or several acting in tandem -- put in
 place to satisfy an &%Obligation a &%Policy confers on the &%CognitiveAgent
 accountable for meeting a defined security requirement. A &%SecurityControl
 applies to a given context only when a matching &%Obligation actually holds
-there; it is not universally applicable regardless of context.")
+there. It is not universally applicable regardless of context.")
 
 ;; rule: a SecurityControl is always either an Object (a lock, an RFID
 ;; reader) or a Process (a guard's periodic credential check, a firewall


### PR DESCRIPTION
SecurityControl's documentation string (added in #613) has a semicolon inside a multiline doc string. The KIF parser reads a semicolon as a comment delimiter, so it breaks the parse (confirmed via KifFileChecker -C: extraneous input <EOF> at the documentation form). Replaces the semicolon with a period; no content change.