### PR TITLE
Fix ViolatedKnapsack naming convention

### DIFF
--- a/development/Cyber.kif
+++ b/development/Cyber.kif
@@ -330,12 +330,12 @@ cost.")
     (not (equal ?TOT1 ?TOT2))))
 
 ;; ============================================================
-;; violatedKnapsack (RelationalAttribute)
+;; ViolatedKnapsack (RelationalAttribute)
 ;; ============================================================
 
-(instance violatedKnapsack RelationalAttribute)
-(termFormat EnglishLanguage violatedKnapsack "violated knapsack")
-(documentation violatedKnapsack EnglishLanguage "An &%Attribute of an
+(instance ViolatedKnapsack RelationalAttribute)
+(termFormat EnglishLanguage ViolatedKnapsack "violated knapsack")
+(documentation ViolatedKnapsack EnglishLanguage "An &%Attribute of an
 &%AutonomousAgent that holds during a &%TimeInterval when the agent's
 &%aggregateCyberCost for that interval exceeds their
 &%operationalBudget. Agent-relative: within the same interval one
@@ -352,7 +352,7 @@ same agent may satisfy in one interval and violate in another.")
     (measure ?TOTAL ?TOTAL_AMOUNT)
     (greaterThan ?TOTAL_AMOUNT ?BUDGET_AMOUNT))
   (holdsDuring ?T
-    (attribute ?AGENT violatedKnapsack)))
+    (attribute ?AGENT ViolatedKnapsack)))
 
 (exists (?A1 ?A2 ?T ?B1 ?B2 ?TOT1 ?TOT2 ?BA1 ?BA2 ?TA1 ?TA2)
   (and
@@ -540,7 +540,7 @@ is whether a known or off-the-shelf exploit already exists (see
 Capacity-relative: the same exploit cost can be
 affordable for one agent and unaffordable for another depending on their
 &%operationalBudget, both directly and as a contributor to
-&%aggregateCyberCost, which &%violatedKnapsack compares against
+&%aggregateCyberCost, which &%ViolatedKnapsack compares against
 &%operationalBudget. Single-valued: for a given vulnerability and agent
 there is at most one exploit cost.")
 
@@ -811,7 +811,7 @@ expertise costs. One of five cost components summed into &%exploitCost.")
 ;; rule: exploitCost is capacity-relative -- the identical cost can be
 ;; affordable for one agent and unaffordable for another depending on
 ;; operationalBudget, independent of exploitCost's own contribution to
-;; aggregateCyberCost/violatedKnapsack above
+;; aggregateCyberCost/ViolatedKnapsack above
 
 (exists (?VUL ?A1 ?A2 ?B1 ?B2 ?COST)
   (and


### PR DESCRIPTION
violatedKnapsack is declared as an instance of RelationalAttribute, so it is an attribute, not a relation, and should follow the capitalized attribute naming convention (Rigid, Likely) rather than the lowercase relation convention. Renames it consistently across its declaration, termFormat, documentation, and every usage site. No other file in the corpus references the old lowercase name.