### PR TITLE
Refactor ROE measures with 'roe' prefix

### DIFF
--- a/development/ROE_Supplementary.kif
+++ b/development/ROE_Supplementary.kif
@@ -22,6 +22,15 @@
 ;; Load after ROE_Master.kif and before ROE_Series.kif.
 ;; ===========================================================================
 
+;; Naming. Relations specific to this domain carry an roe prefix, so that a
+;; name like roeActionAuthorized cannot be mistaken for a general relation
+;; when the files are read alongside the rest of SUMO. Two relations are
+;; deliberately left unprefixed. &%furthers is the positive counterpart of the
+;; SUMO relation &%hinders, which has no positive form, and it is stated in
+;; terms general enough to hold outside this domain; prefixing it would fix as
+;; domain-specific something that is not. &%unsafeProximity belongs to the
+;; COLREGs scenario pipeline rather than to ROE.
+
 ;; ===========================================================================
 ;; 87. ROE measure infrastructure
 ;; ===========================================================================
@@ -34,29 +43,29 @@
 (documentation ROEMeasure EnglishLanguage "A single lettered rule within an &%ROESeries, for example rule 21 C. A measure is a catalog entry and binds no one on its own. It acquires normative effect only through an &%ROEActivation, by which competent authority places it in force for a particular operation and supplies any value its (SPECIFY ...) placeholder requires.")
 (termFormat EnglishLanguage ROEMeasure "ROE measure")
 
-(instance measureInSeries BinaryPredicate)
-(domain measureInSeries 1 ROEMeasure)
-(domain measureInSeries 2 ROESeries)
-(documentation measureInSeries EnglishLanguage "(measureInSeries ?M ?S) means that the ROE measure ?M is a rule within the series ?S.")
-(termFormat EnglishLanguage measureInSeries "measure in series")
+(instance roeMeasureInSeries BinaryPredicate)
+(domain roeMeasureInSeries 1 ROEMeasure)
+(domain roeMeasureInSeries 2 ROESeries)
+(documentation roeMeasureInSeries EnglishLanguage "(roeMeasureInSeries ?M ?S) means that the ROE measure ?M is a rule within the series ?S.")
+(termFormat EnglishLanguage roeMeasureInSeries "measure in series")
 
-(instance measureAuthorizes BinaryPredicate)
-(domain measureAuthorizes 1 ROEMeasure)
-(domainSubclass measureAuthorizes 2 Process)
-(documentation measureAuthorizes EnglishLanguage "(measureAuthorizes ?M ?CLASS) means that the ROE measure ?M authorizes actions of class ?CLASS. The scope of the measure is carried by the definition of ?CLASS. The Newport phrase 'up to and including deadly force' therefore needs no ceiling relation: a measure naming the wider class already authorizes every instance of its non-deadly subclass.")
-(termFormat EnglishLanguage measureAuthorizes "measure authorizes")
+(instance roeMeasureAuthorizes BinaryPredicate)
+(domain roeMeasureAuthorizes 1 ROEMeasure)
+(domainSubclass roeMeasureAuthorizes 2 Process)
+(documentation roeMeasureAuthorizes EnglishLanguage "(roeMeasureAuthorizes ?M ?CLASS) means that the ROE measure ?M authorizes actions of class ?CLASS. The scope of the measure is carried by the definition of ?CLASS. The Newport phrase 'up to and including deadly force' therefore needs no ceiling relation: a measure naming the wider class already authorizes every instance of its non-deadly subclass.")
+(termFormat EnglishLanguage roeMeasureAuthorizes "measure authorizes")
 
-(instance measureProhibits BinaryPredicate)
-(domain measureProhibits 1 ROEMeasure)
-(domainSubclass measureProhibits 2 Process)
-(documentation measureProhibits EnglishLanguage "(measureProhibits ?M ?CLASS) means that the ROE measure ?M prohibits actions of class ?CLASS. A prohibition withholds authority over the whole class and so admits no ceiling.")
-(termFormat EnglishLanguage measureProhibits "measure prohibits")
+(instance roeMeasureProhibits BinaryPredicate)
+(domain roeMeasureProhibits 1 ROEMeasure)
+(domainSubclass roeMeasureProhibits 2 Process)
+(documentation roeMeasureProhibits EnglishLanguage "(roeMeasureProhibits ?M ?CLASS) means that the ROE measure ?M prohibits actions of class ?CLASS. A prohibition withholds authority over the whole class and so admits no ceiling.")
+(termFormat EnglishLanguage roeMeasureProhibits "measure prohibits")
 
-(instance measureRequiresParameter BinaryPredicate)
-(domain measureRequiresParameter 1 ROEMeasure)
-(domainSubclass measureRequiresParameter 2 Entity)
-(documentation measureRequiresParameter EnglishLanguage "(measureRequiresParameter ?M ?CLASS) means the measure ?M carries a (SPECIFY ...) placeholder to be filled by an instance of ?CLASS. A measure carrying such a placeholder is a template rather than a complete norm, and the authorization rules of item 89 will not fire for it unless the corresponding &%activationParameter is supplied.")
-(termFormat EnglishLanguage measureRequiresParameter "measure requires parameter")
+(instance roeMeasureRequiresParameter BinaryPredicate)
+(domain roeMeasureRequiresParameter 1 ROEMeasure)
+(domainSubclass roeMeasureRequiresParameter 2 Entity)
+(documentation roeMeasureRequiresParameter EnglishLanguage "(roeMeasureRequiresParameter ?M ?CLASS) means the measure ?M carries a (SPECIFY ...) placeholder to be filled by an instance of ?CLASS. A measure carrying such a placeholder is a template rather than a complete norm, and the authorization rules of item 89 will not fire for it unless the corresponding &%roeActivationParameter is supplied.")
+(termFormat EnglishLanguage roeMeasureRequiresParameter "measure requires parameter")
 
 ;; The class named here is not checked by the authorization rules. Whether the
 ;; value supplied is of the right kind is a question about how the ROE were
@@ -80,29 +89,29 @@
 ;; is the expensive one, and the distinction is easy to confuse.
 
 (subclass CompleteROEMeasure ROEMeasure)
-(documentation CompleteROEMeasure EnglishLanguage "A measure that carries no (SPECIFY ...) placeholder and is therefore a complete norm as it stands in the compendium, for example rule 23 A. The distinction is drawn as a subclass rather than by a one-argument relation because SUMO has no idiom for such a relation: it provides Binary, Ternary, Quaternary and Quintary Predicate but nothing unary, and the two relations in the knowledge base that take only a first argument are declared VariableArityRelation. The distinction is also asserted positively rather than derived as the absence of a placeholder. The negative form (not (exists (?PC) (measureRequiresParameter ?M ?PC))) draws a Sigma warning for an existential in the antecedent, and simply dropping the existential is unsound: a free variable there is universally quantified over the whole rule, so the rule would fire on any class the measure does not happen to require, and the placeholder check would be bypassed.")
+(documentation CompleteROEMeasure EnglishLanguage "A measure that carries no (SPECIFY ...) placeholder and is therefore a complete norm as it stands in the compendium, for example rule 23 A. The distinction is drawn as a subclass rather than by a one-argument relation because SUMO has no idiom for such a relation: it provides Binary, Ternary, Quaternary and Quintary Predicate but nothing unary, and the two relations in the knowledge base that take only a first argument are declared VariableArityRelation. The distinction is also asserted positively rather than derived as the absence of a placeholder. The negative form (not (exists (?PC) (roeMeasureRequiresParameter ?M ?PC))) draws a Sigma warning for an existential in the antecedent, and simply dropping the existential is unsound: a free variable there is universally quantified over the whole rule, so the rule would fire on any class the measure does not happen to require, and the placeholder check would be bypassed.")
 (termFormat EnglishLanguage CompleteROEMeasure "complete ROE measure")
 
 (subclass TemplateROEMeasure ROEMeasure)
-(documentation TemplateROEMeasure EnglishLanguage "A measure that carries a (SPECIFY ...) placeholder and is therefore a template rather than a complete norm, for example rule 21 E. It has effect only when an &%ROEActivation supplies a value through &%activationParameter.")
+(documentation TemplateROEMeasure EnglishLanguage "A measure that carries a (SPECIFY ...) placeholder and is therefore a template rather than a complete norm, for example rule 21 E. It has effect only when an &%ROEActivation supplies a value through &%roeActivationParameter.")
 (termFormat EnglishLanguage TemplateROEMeasure "template ROE measure")
 
 
 
 
 ;; Membership of both subclasses is asserted per measure rather than derived.
-;; Deriving the template case from (measureRequiresParameter ?M ?PC) leaves ?PC
+;; Deriving the template case from (roeMeasureRequiresParameter ?M ?PC) leaves ?PC
 ;; occurring in a single literal, which Sigma reports as a variable used only
 ;; once, and no reformulation avoids that: the rule turns on whether a
 ;; placeholder exists, not on which class fills it. The wrong-typed parameter
 ;; case is caught instead by Rule 4 of item 89, whose antecedent requires the
 ;; supplied value to be an instance of the required class.
 
-(instance measureSubsumes BinaryPredicate)
-(domain measureSubsumes 1 ROEMeasure)
-(domain measureSubsumes 2 ROEMeasure)
-(documentation measureSubsumes EnglishLanguage "(measureSubsumes ?M1 ?M2) means every action authorized by ?M2 is also authorized by ?M1. Transitivity and irreflexivity are not declared: the SUMO transitivity axiom carries a variable in predicate position, and expanding it enlarges the search space out of proportion to the number of classes involved here.")
-(termFormat EnglishLanguage measureSubsumes "measure subsumes")
+(instance roeMeasureSubsumes BinaryPredicate)
+(domain roeMeasureSubsumes 1 ROEMeasure)
+(domain roeMeasureSubsumes 2 ROEMeasure)
+(documentation roeMeasureSubsumes EnglishLanguage "(roeMeasureSubsumes ?M1 ?M2) means every action authorized by ?M2 is also authorized by ?M1. Transitivity and irreflexivity are not declared: the SUMO transitivity axiom carries a variable in predicate position, and expanding it enlarges the search space out of proportion to the number of classes involved here.")
+(termFormat EnglishLanguage roeMeasureSubsumes "measure subsumes")
 
 ;; ---------------------------------------------------------------------------
 ;; Activation
@@ -119,7 +128,7 @@
 ;; Note on a measure kind distinction that was tried and removed. Permissive
 ;; and prohibitive measures were once separated into two subclasses, and the
 ;; action rules carried a conjunct naming the kind, in order to anchor the
-;; disproof of actionProhibited: without it the prover must establish that a
+;; disproof of roeActionProhibited: without it the prover must establish that a
 ;; permissive measure in force prohibits nothing. That turned out to need no
 ;; anchoring at all. Where a conjunct has no matching ground fact the branch
 ;; simply finds no resolution partner and dies, which is the cheap case; the
@@ -129,64 +138,64 @@
 ;; the remedy rather than by the problem.
 
 (subclass ROEActivation Proposition)
-(documentation ROEActivation EnglishLanguage "An individual act of placing an &%ROEMeasure in force for a particular operation. It carries the measure through &%activationMeasure, the operation through &%activationOperation, and the value supplied for a (SPECIFY ...) placeholder through &%activationParameter. Reifying the activation is what allows a parameterized measure to constrain particular actions rather than a whole class.")
+(documentation ROEActivation EnglishLanguage "An individual act of placing an &%ROEMeasure in force for a particular operation. It carries the measure through &%roeActivationMeasure, the operation through &%roeActivationOperation, and the value supplied for a (SPECIFY ...) placeholder through &%roeActivationParameter. Reifying the activation is what allows a parameterized measure to constrain particular actions rather than a whole class.")
 (termFormat EnglishLanguage ROEActivation "ROE activation")
 
-(instance activationMeasure BinaryPredicate)
-(domain activationMeasure 1 ROEActivation)
-(domain activationMeasure 2 ROEMeasure)
-(termFormat EnglishLanguage activationMeasure "activation measure")
+(instance roeActivationMeasure BinaryPredicate)
+(domain roeActivationMeasure 1 ROEActivation)
+(domain roeActivationMeasure 2 ROEMeasure)
+(termFormat EnglishLanguage roeActivationMeasure "activation measure")
 
-(instance activationOperation BinaryPredicate)
-(domain activationOperation 1 ROEActivation)
-(domain activationOperation 2 MilitaryOperation)
-(termFormat EnglishLanguage activationOperation "activation operation")
+(instance roeActivationOperation BinaryPredicate)
+(domain roeActivationOperation 1 ROEActivation)
+(domain roeActivationOperation 2 MilitaryOperation)
+(termFormat EnglishLanguage roeActivationOperation "activation operation")
 
-(instance activationParameter BinaryPredicate)
-(domain activationParameter 1 ROEActivation)
-(domain activationParameter 2 Entity)
-(documentation activationParameter EnglishLanguage "(activationParameter ?ACTV ?X) means ?X is the entity supplied for the (SPECIFY ...) placeholder of the measure activated by ?ACTV. An action falls within a parameterized measure only if ?X is involved in it, in the sense of &%involvedInEvent.")
-(termFormat EnglishLanguage activationParameter "activation parameter")
+(instance roeActivationParameter BinaryPredicate)
+(domain roeActivationParameter 1 ROEActivation)
+(domain roeActivationParameter 2 Entity)
+(documentation roeActivationParameter EnglishLanguage "(roeActivationParameter ?ACTV ?X) means ?X is the entity supplied for the (SPECIFY ...) placeholder of the measure activated by ?ACTV. An action falls within a parameterized measure only if ?X is involved in it, in the sense of &%involvedInEvent.")
+(termFormat EnglishLanguage roeActivationParameter "activation parameter")
 
 (instance roeInForce BinaryPredicate)
 (domain roeInForce 1 ROEMeasure)
 (domain roeInForce 2 MilitaryOperation)
-(documentation roeInForce EnglishLanguage "(roeInForce ?M ?OP) means that the ROE measure ?M has been placed in force by competent authority for the operation ?OP. It is derived from an &%ROEActivation and says nothing about which value was supplied for a (SPECIFY ...) placeholder; that is carried by &%activationParameter. A dedicated predicate is used rather than &%confersNorm, &%confersRight or &%permits because each of those takes a reified &%Formula as one of its arguments, and Formula-valued positions are where the search cost of the authorization rules concentrates.")
+(documentation roeInForce EnglishLanguage "(roeInForce ?M ?OP) means that the ROE measure ?M has been placed in force by competent authority for the operation ?OP. It is derived from an &%ROEActivation and says nothing about which value was supplied for a (SPECIFY ...) placeholder; that is carried by &%roeActivationParameter. A dedicated predicate is used rather than &%confersNorm, &%confersRight or &%permits because each of those takes a reified &%Formula as one of its arguments, and Formula-valued positions are where the search cost of the authorization rules concentrates.")
 (termFormat EnglishLanguage roeInForce "ROE in force")
 
 (=>
   (and
-    (activationMeasure ?ACTV ?M)
-    (activationOperation ?ACTV ?OP))
+    (roeActivationMeasure ?ACTV ?M)
+    (roeActivationOperation ?ACTV ?OP))
   (roeInForce ?M ?OP))
 
 ;; ---------------------------------------------------------------------------
 ;; Outcome predicates
 ;; ---------------------------------------------------------------------------
 
-(instance actionAuthorized BinaryPredicate)
-(domain actionAuthorized 1 Process)
-(domain actionAuthorized 2 MilitaryOperation)
-(documentation actionAuthorized EnglishLanguage "(actionAuthorized ?ACT ?OP) means the action ?ACT falls within the authority granted by some measure in force for the operation ?OP. It does not mean the action may be taken: a narrower measure may prohibit it, and necessity and proportionality are separate gates. The net result under ROE is &%actionPermissible.")
-(termFormat EnglishLanguage actionAuthorized "action authorized")
+(instance roeActionAuthorized BinaryPredicate)
+(domain roeActionAuthorized 1 Process)
+(domain roeActionAuthorized 2 MilitaryOperation)
+(documentation roeActionAuthorized EnglishLanguage "(roeActionAuthorized ?ACT ?OP) means the action ?ACT falls within the authority granted by some measure in force for the operation ?OP. It does not mean the action may be taken: a narrower measure may prohibit it, and necessity and proportionality are separate gates. The net result under ROE is &%roeActionPermissible.")
+(termFormat EnglishLanguage roeActionAuthorized "action authorized")
 
-(instance actionProhibited BinaryPredicate)
-(domain actionProhibited 1 Process)
-(domain actionProhibited 2 MilitaryOperation)
-(documentation actionProhibited EnglishLanguage "(actionProhibited ?ACT ?OP) means the action ?ACT falls within a class prohibited by some measure in force for the operation ?OP. Authorization and prohibition are derived independently, so both may hold of one action. That is not by itself an error: Newport series are drafted so that a narrow prohibition may be layered on a broad permission, as rule 23 B is on rule 23 E.")
-(termFormat EnglishLanguage actionProhibited "action prohibited")
+(instance roeActionProhibited BinaryPredicate)
+(domain roeActionProhibited 1 Process)
+(domain roeActionProhibited 2 MilitaryOperation)
+(documentation roeActionProhibited EnglishLanguage "(roeActionProhibited ?ACT ?OP) means the action ?ACT falls within a class prohibited by some measure in force for the operation ?OP. Authorization and prohibition are derived independently, so both may hold of one action. That is not by itself an error: Newport series are drafted so that a narrow prohibition may be layered on a broad permission, as rule 23 B is on rule 23 E.")
+(termFormat EnglishLanguage roeActionProhibited "action prohibited")
 
-(instance actionPermissible BinaryPredicate)
-(domain actionPermissible 1 Process)
-(domain actionPermissible 2 MilitaryOperation)
-(documentation actionPermissible EnglishLanguage "(actionPermissible ?ACT ?OP) means the action ?ACT is authorized by the ROE in force for ?OP and is not prohibited by them. Where a broad authorization and a narrow prohibition both reach an action, the prohibition governs, which is the principle that the more specific rule defeats the more general. Permissibility under ROE is not lawfulness: an action must still satisfy LOAC, necessity and proportionality.")
-(termFormat EnglishLanguage actionPermissible "action permissible")
+(instance roeActionPermissible BinaryPredicate)
+(domain roeActionPermissible 1 Process)
+(domain roeActionPermissible 2 MilitaryOperation)
+(documentation roeActionPermissible EnglishLanguage "(roeActionPermissible ?ACT ?OP) means the action ?ACT is authorized by the ROE in force for ?OP and is not prohibited by them. Where a broad authorization and a narrow prohibition both reach an action, the prohibition governs, which is the principle that the more specific rule defeats the more general. Permissibility under ROE is not lawfulness: an action must still satisfy LOAC, necessity and proportionality.")
+(termFormat EnglishLanguage roeActionPermissible "action permissible")
 
-(instance noProhibitionReaches BinaryPredicate)
-(domain noProhibitionReaches 1 Process)
-(domain noProhibitionReaches 2 MilitaryOperation)
-(documentation noProhibitionReaches EnglishLanguage "(noProhibitionReaches ?ACT ?OP) states that no prohibitive measure in force for ?OP reaches ?ACT. It is asserted per scenario rather than derived. Writing the permissibility rule with (not (actionProhibited ?ACT ?OP)) in the antecedent instead makes the rule unable to fire at all: in first-order logic the failure to derive a prohibition does not license its negation, so an action that no prohibition reaches could never be shown permissible. This is the same closure discipline used for the restrictive default. The closure is stated over the measures in force rather than over the state of the world, and that asymmetry is deliberate. An ROE implementation message is an authoritative and complete statement of which measures a commander holds, so reading it as complete is not a guess. What an adversary is doing is known only as far as it has been observed, and no such assumption is made there.")
-(termFormat EnglishLanguage noProhibitionReaches "no prohibition reaches")
+(instance roeNoProhibitionReaches BinaryPredicate)
+(domain roeNoProhibitionReaches 1 Process)
+(domain roeNoProhibitionReaches 2 MilitaryOperation)
+(documentation roeNoProhibitionReaches EnglishLanguage "(roeNoProhibitionReaches ?ACT ?OP) states that no prohibitive measure in force for ?OP reaches ?ACT. It is asserted per scenario rather than derived. Writing the permissibility rule with (not (roeActionProhibited ?ACT ?OP)) in the antecedent instead makes the rule unable to fire at all: in first-order logic the failure to derive a prohibition does not license its negation, so an action that no prohibition reaches could never be shown permissible. This is the same closure discipline used for the restrictive default. The closure is stated over the measures in force rather than over the state of the world, and that asymmetry is deliberate. An ROE implementation message is an authoritative and complete statement of which measures a commander holds, so reading it as complete is not a guess. What an adversary is doing is known only as far as it has been observed, and no such assumption is made there.")
+(termFormat EnglishLanguage roeNoProhibitionReaches "no prohibition reaches")
 
 ;; ===========================================================================
 ;; 88. Deontic layer
@@ -208,14 +217,14 @@
 ;;
 ;; This layer is not reached by the authorization rules. Both &%permits and
 ;; &%prohibits take a reified &%Formula, which is the argument position where
-;; search cost concentrates, so inference runs on &%actionAuthorized instead.
+;; search cost concentrates, so inference runs on &%roeActionAuthorized instead.
 ;; ===========================================================================
 
-(instance issuingAuthority BinaryPredicate)
-(domain issuingAuthority 1 MilitaryOperation)
-(domain issuingAuthority 2 AutonomousAgent)
-(documentation issuingAuthority EnglishLanguage "(issuingAuthority ?OP ?AUTH) means ?AUTH is the authority whose ROE govern the operation ?OP. In a multinational force different contributing States may impose different ROE on their own units, so the authority is carried explicitly rather than assumed.")
-(termFormat EnglishLanguage issuingAuthority "issuing authority")
+(instance roeIssuingAuthority BinaryPredicate)
+(domain roeIssuingAuthority 1 MilitaryOperation)
+(domain roeIssuingAuthority 2 AutonomousAgent)
+(documentation roeIssuingAuthority EnglishLanguage "(roeIssuingAuthority ?OP ?AUTH) means ?AUTH is the authority whose ROE govern the operation ?OP. In a multinational force different contributing States may impose different ROE on their own units, so the authority is carried explicitly rather than assumed.")
+(termFormat EnglishLanguage roeIssuingAuthority "issuing authority")
 
 ;; Rule 1: The authority behind an operation is the headquarters that issued
 ;; the ROE authorization to the unit conducting it.
@@ -227,14 +236,14 @@
     (destination ?AUTHMSG ?UNIT)
     (instance ?OP MilitaryOperation)
     (agent ?OP ?UNIT))
-  (issuingAuthority ?OP ?HQ))
+  (roeIssuingAuthority ?OP ?HQ))
 
 ;; Rule 2: A measure in force confers a permission held by the authority.
 (=>
   (and
     (roeInForce ?M ?OP)
-    (measureAuthorizes ?M ?C)
-    (issuingAuthority ?OP ?AUTH))
+    (roeMeasureAuthorizes ?M ?C)
+    (roeIssuingAuthority ?OP ?AUTH))
   (permits ?AUTH
     (exists (?A)
       (instance ?A ?C))))
@@ -243,8 +252,8 @@
 (=>
   (and
     (roeInForce ?M ?OP)
-    (measureProhibits ?M ?C)
-    (issuingAuthority ?OP ?AUTH))
+    (roeMeasureProhibits ?M ?C)
+    (roeIssuingAuthority ?OP ?AUTH))
   (prohibits ?AUTH
     (exists (?A)
       (instance ?A ?C))))
@@ -257,10 +266,10 @@
 ;; the class the other authorizes.
 (=>
   (and
-    (measureAuthorizes ?M1 ?C1)
-    (measureAuthorizes ?M2 ?C2)
+    (roeMeasureAuthorizes ?M1 ?C1)
+    (roeMeasureAuthorizes ?M2 ?C2)
     (subclass ?C2 ?C1))
-  (measureSubsumes ?M1 ?M2))
+  (roeMeasureSubsumes ?M1 ?M2))
 
 ;; Rule 2: A prohibition and an authorization cannot both be in force for the
 ;; same operation where the authorized class falls within the prohibited one.
@@ -270,8 +279,8 @@
 ;; is resolved at the action level by Rule 6 instead.
 (=>
   (and
-    (measureProhibits ?M1 ?C1)
-    (measureAuthorizes ?M2 ?C2)
+    (roeMeasureProhibits ?M1 ?C1)
+    (roeMeasureAuthorizes ?M2 ?C2)
     (subclass ?C2 ?C1)
     (roeInForce ?M1 ?OP))
   (not
@@ -281,12 +290,12 @@
 ;; authorized by a measure in force that carries no placeholder.
 (=>
   (and
-    (activationMeasure ?ACTV ?M)
-    (activationOperation ?ACTV ?OP)
+    (roeActivationMeasure ?ACTV ?M)
+    (roeActivationOperation ?ACTV ?OP)
     (instance ?M CompleteROEMeasure)
-    (measureAuthorizes ?M ?C)
+    (roeMeasureAuthorizes ?M ?C)
     (instance ?ACT ?C))
-  (actionAuthorized ?ACT ?OP))
+  (roeActionAuthorized ?ACT ?OP))
 
 ;; Rule 4: An action is authorized under a measure that carries a placeholder
 ;; only when the supplied value is involved in the action. Without this
@@ -294,55 +303,55 @@
 ;; at all, rather than of the persons actually specified.
 (=>
   (and
-    (activationMeasure ?ACTV ?M)
-    (activationOperation ?ACTV ?OP)
-    (activationParameter ?ACTV ?X)
+    (roeActivationMeasure ?ACTV ?M)
+    (roeActivationOperation ?ACTV ?OP)
+    (roeActivationParameter ?ACTV ?X)
     (instance ?M TemplateROEMeasure)
-    (measureAuthorizes ?M ?C)
+    (roeMeasureAuthorizes ?M ?C)
     (instance ?ACT ?C)
     (involvedInEvent ?ACT ?X))
-  (actionAuthorized ?ACT ?OP))
+  (roeActionAuthorized ?ACT ?OP))
 
 ;; Rule 5: An action is prohibited when it is an instance of a class
 ;; prohibited by a measure in force that carries no placeholder.
 (=>
   (and
-    (activationMeasure ?ACTV ?M)
-    (activationOperation ?ACTV ?OP)
+    (roeActivationMeasure ?ACTV ?M)
+    (roeActivationOperation ?ACTV ?OP)
     (instance ?M CompleteROEMeasure)
-    (measureProhibits ?M ?C)
+    (roeMeasureProhibits ?M ?C)
     (instance ?ACT ?C))
-  (actionProhibited ?ACT ?OP))
+  (roeActionProhibited ?ACT ?OP))
 
 ;; Rule 5b: A prohibition that carries a placeholder reaches only actions in
 ;; which the supplied value is involved. Rule 23 B forbids warning shots in the
 ;; vicinity of specified elements, not in the vicinity of anything whatever.
 (=>
   (and
-    (activationMeasure ?ACTV ?M)
-    (activationOperation ?ACTV ?OP)
-    (activationParameter ?ACTV ?X)
+    (roeActivationMeasure ?ACTV ?M)
+    (roeActivationOperation ?ACTV ?OP)
+    (roeActivationParameter ?ACTV ?X)
     (instance ?M TemplateROEMeasure)
-    (measureProhibits ?M ?C)
+    (roeMeasureProhibits ?M ?C)
     (instance ?ACT ?C)
     (involvedInEvent ?ACT ?X))
-  (actionProhibited ?ACT ?OP))
+  (roeActionProhibited ?ACT ?OP))
 
 ;; Rule 6: An authorized action that no measure in force prohibits is
 ;; permissible. Where both reach the action the prohibition governs, since the
 ;; more specific rule defeats the more general.
 (=>
   (and
-    (actionAuthorized ?ACT ?OP)
-    (noProhibitionReaches ?ACT ?OP))
-  (actionPermissible ?ACT ?OP))
+    (roeActionAuthorized ?ACT ?OP)
+    (roeNoProhibitionReaches ?ACT ?OP))
+  (roeActionPermissible ?ACT ?OP))
 
 ;; ---------------------------------------------------------------------------
 ;; The restrictive default
 ;;
 ;; The Newport Handbook takes a restrictive approach: an action is not
 ;; authorized unless a measure authorizes it. Represented as the failure to
-;; derive actionAuthorized, that default yields a saturation result rather than
+;; derive roeActionAuthorized, that default yields a saturation result rather than
 ;; a proof, and so carries no inference chain for what is in fact the ordinary
 ;; case. It is stated positively instead, from an asserted closure fact.
 ;;
@@ -352,42 +361,42 @@
 ;; extending to them would need it.
 ;; ---------------------------------------------------------------------------
 
-(instance seriesAddresses BinaryPredicate)
-(domain seriesAddresses 1 ROESeries)
-(domainSubclass seriesAddresses 2 Process)
-(documentation seriesAddresses EnglishLanguage "(seriesAddresses ?S ?CLASS) means that some measure of series ?S bears on actions of class ?CLASS, so that ?S is the series to consult about them.")
-(termFormat EnglishLanguage seriesAddresses "series addresses")
+(instance roeSeriesAddresses BinaryPredicate)
+(domain roeSeriesAddresses 1 ROESeries)
+(domainSubclass roeSeriesAddresses 2 Process)
+(documentation roeSeriesAddresses EnglishLanguage "(roeSeriesAddresses ?S ?CLASS) means that some measure of series ?S bears on actions of class ?CLASS, so that ?S is the series to consult about them.")
+(termFormat EnglishLanguage roeSeriesAddresses "series addresses")
 
 (=>
   (and
-    (measureInSeries ?M ?S)
-    (measureAuthorizes ?M ?C))
-  (seriesAddresses ?S ?C))
+    (roeMeasureInSeries ?M ?S)
+    (roeMeasureAuthorizes ?M ?C))
+  (roeSeriesAddresses ?S ?C))
 
 (=>
   (and
-    (measureInSeries ?M ?S)
-    (measureProhibits ?M ?C))
-  (seriesAddresses ?S ?C))
+    (roeMeasureInSeries ?M ?S)
+    (roeMeasureProhibits ?M ?C))
+  (roeSeriesAddresses ?S ?C))
 
-(instance seriesNotAddressed BinaryPredicate)
-(domain seriesNotAddressed 1 ROESeries)
-(domain seriesNotAddressed 2 MilitaryOperation)
-(documentation seriesNotAddressed EnglishLanguage "(seriesNotAddressed ?S ?OP) states that no measure of series ?S has been placed in force for operation ?OP. It is asserted per scenario. Deriving it from the absence of an activation would require treating the record of activations as complete. That assumption is warranted here, since an ROE implementation message states in full which measures are held, but it is not warranted about the state of the world and is not made there. Because the fact is asserted rather than derived, it can fall out of step with the activations recorded alongside it; &%closureConflict is the check for that.")
-(termFormat EnglishLanguage seriesNotAddressed "series not addressed")
+(instance roeSeriesNotAddressed BinaryPredicate)
+(domain roeSeriesNotAddressed 1 ROESeries)
+(domain roeSeriesNotAddressed 2 MilitaryOperation)
+(documentation roeSeriesNotAddressed EnglishLanguage "(roeSeriesNotAddressed ?S ?OP) states that no measure of series ?S has been placed in force for operation ?OP. It is asserted per scenario. Deriving it from the absence of an activation would require treating the record of activations as complete. That assumption is warranted here, since an ROE implementation message states in full which measures are held, but it is not warranted about the state of the world and is not made there. Because the fact is asserted rather than derived, it can fall out of step with the activations recorded alongside it; &%roeClosureConflict is the check for that.")
+(termFormat EnglishLanguage roeSeriesNotAddressed "series not addressed")
 
-(instance actionUnauthorized BinaryPredicate)
-(domain actionUnauthorized 1 Process)
-(domain actionUnauthorized 2 MilitaryOperation)
-(documentation actionUnauthorized EnglishLanguage "(actionUnauthorized ?ACT ?OP) means that the series governing ?ACT has been placed in force for ?OP in no part, so that under the restrictive default no authority for ?ACT exists. Distinct from &%actionProhibited, which requires a measure forbidding the action: an unauthorized action is one no one was given, a prohibited action is one someone was refused.")
-(termFormat EnglishLanguage actionUnauthorized "action unauthorized")
+(instance roeActionUnauthorized BinaryPredicate)
+(domain roeActionUnauthorized 1 Process)
+(domain roeActionUnauthorized 2 MilitaryOperation)
+(documentation roeActionUnauthorized EnglishLanguage "(roeActionUnauthorized ?ACT ?OP) means that the series governing ?ACT has been placed in force for ?OP in no part, so that under the restrictive default no authority for ?ACT exists. Distinct from &%roeActionProhibited, which requires a measure forbidding the action: an unauthorized action is one no one was given, a prohibited action is one someone was refused.")
+(termFormat EnglishLanguage roeActionUnauthorized "action unauthorized")
 
 (=>
   (and
-    (seriesNotAddressed ?S ?OP)
-    (seriesAddresses ?S ?C)
+    (roeSeriesNotAddressed ?S ?OP)
+    (roeSeriesAddresses ?S ?C)
     (instance ?ACT ?C))
-  (actionUnauthorized ?ACT ?OP))
+  (roeActionUnauthorized ?ACT ?OP))
 
 ;; ---------------------------------------------------------------------------
 ;; Closure conflict
@@ -404,31 +413,31 @@
 ;; Theorem for every query, so a data entry error would silently satisfy every
 ;; test expecting a positive answer. A flag leaves the knowledge base
 ;; consistent and can be queried directly, at the cost of having to be asked.
-;; Scenario files should therefore carry (query (closureConflict ...)) with
+;; Scenario files should therefore carry (query (roeClosureConflict ...)) with
 ;; (answer no) alongside their substantive queries.
 ;; ---------------------------------------------------------------------------
 
-(instance closureConflict BinaryPredicate)
-(domain closureConflict 1 Entity)
-(domain closureConflict 2 MilitaryOperation)
-(documentation closureConflict EnglishLanguage "(closureConflict ?X ?OP) means that a closure fact asserted for ?OP is contradicted by the activations recorded for ?OP. The first argument is the action or the series the closure fact was asserted about. Deriving this predicate indicates an error in the scenario, not a conflict of norms.")
-(termFormat EnglishLanguage closureConflict "closure conflict")
+(instance roeClosureConflict BinaryPredicate)
+(domain roeClosureConflict 1 Entity)
+(domain roeClosureConflict 2 MilitaryOperation)
+(documentation roeClosureConflict EnglishLanguage "(roeClosureConflict ?X ?OP) means that a closure fact asserted for ?OP is contradicted by the activations recorded for ?OP. The first argument is the action or the series the closure fact was asserted about. Deriving this predicate indicates an error in the scenario, not a conflict of norms.")
+(termFormat EnglishLanguage roeClosureConflict "closure conflict")
 
 ;; Rule 7: An action said to be reached by no prohibition, which a measure in
 ;; force does prohibit.
 (=>
   (and
-    (noProhibitionReaches ?ACT ?OP)
-    (actionProhibited ?ACT ?OP))
-  (closureConflict ?ACT ?OP))
+    (roeNoProhibitionReaches ?ACT ?OP)
+    (roeActionProhibited ?ACT ?OP))
+  (roeClosureConflict ?ACT ?OP))
 
 ;; Rule 8: A series said not to be addressed, one of whose measures is in force.
 (=>
   (and
-    (seriesNotAddressed ?S ?OP)
-    (measureInSeries ?M ?S)
+    (roeSeriesNotAddressed ?S ?OP)
+    (roeMeasureInSeries ?M ?S)
     (roeInForce ?M ?OP))
-  (closureConflict ?S ?OP))
+  (roeClosureConflict ?S ?OP))
 
 ;; ===========================================================================
 ;; 90. Shared action qualifications
@@ -440,21 +449,21 @@
 (documentation furthers EnglishLanguage "(furthers ?P1 ?P2) means that ?P1 is carried out in order to bring about or advance ?P2. SUMO provides &%hinders for the negative case but has no positive counterpart holding between two process individuals: &%hasPurpose is the nearest relation and takes a reified &%Formula as its second argument, which the authorization rules cannot carry. This relation is introduced to fill that gap. It is deliberately narrower than &%subProcess, which says only that one process is part of another and would classify every use of force occurring during an operation, including force used in self-defense, as force for mission accomplishment.")
 (termFormat EnglishLanguage furthers "furthers")
 
-(instance compelsComplianceWith BinaryPredicate)
-(domain compelsComplianceWith 1 Process)
-(domain compelsComplianceWith 2 Order)
-(documentation compelsComplianceWith EnglishLanguage "(compelsComplianceWith ?P ?ORD) means that ?P is carried out in order to induce the party addressed by ?ORD to comply with it.")
-(termFormat EnglishLanguage compelsComplianceWith "compels compliance with")
+(instance roeCompelsComplianceWith BinaryPredicate)
+(domain roeCompelsComplianceWith 1 Process)
+(domain roeCompelsComplianceWith 2 Order)
+(documentation roeCompelsComplianceWith EnglishLanguage "(roeCompelsComplianceWith ?P ?ORD) means that ?P is carried out in order to induce the party addressed by ?ORD to comply with it.")
+(termFormat EnglishLanguage roeCompelsComplianceWith "compels compliance with")
 
 (subclass ComplianceCompulsion Process)
-(documentation ComplianceCompulsion EnglishLanguage "A process carried out to induce compliance with an order already issued. The Newport compendium uses the phrase 'to compel compliance with (SPECIFY instructions)' in several series, and this class carries that qualification once rather than repeating it in each. Membership turns on &%compelsComplianceWith: an earlier version derived it from the process and the order merely sharing a target, which made any process directed at the addressee of any order a compliance compulsion.")
+(documentation ComplianceCompulsion EnglishLanguage "A process carried out to induce compliance with an order already issued. The Newport compendium uses the phrase 'to compel compliance with (SPECIFY instructions)' in several series, and this class carries that qualification once rather than repeating it in each. Membership turns on &%roeCompelsComplianceWith: an earlier version derived it from the process and the order merely sharing a target, which made any process directed at the addressee of any order a compliance compulsion.")
 (termFormat EnglishLanguage ComplianceCompulsion "compliance compulsion")
 
 (=>
   (and
     (instance ?P Process)
     (instance ?ORD Order)
-    (compelsComplianceWith ?P ?ORD))
+    (roeCompelsComplianceWith ?P ?ORD))
   (instance ?P ComplianceCompulsion))
 
 ;; ===========================================================================


### PR DESCRIPTION
This update standardizes the naming of ROE-specific relations to make their scope explicit and consistent with the existing naming convention. In particular, measureAuthorizes and related ROE-specific terms are renamed with the roe prefix (e.g., roeMeasureAuthorizes). All corresponding references across the ROE files have been updated accordingly.

This is a naming change only and does not alter the underlying semantics or inference behavior.