### PR TITLE
Remove bare existential witnesses for six thesis-relevant terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ WordNetMappings/verb.Framestext
 
 #Linux
 .directory
+
+# local proof/dev scratch, never for upstream
+development/proof-scenarios/
+development/dev-reports/

--- a/development/Cyber.kif
+++ b/development/Cyber.kif
@@ -230,15 +230,6 @@ there is at most one operational budget.")
     (knows ?ATTACKER (operationalBudget ?DEFENDER ?DBUDGET))
     (knows ?DEFENDER (operationalBudget ?ATTACKER ?ABUDGET))))
 
-(exists (?A1 ?A2 ?B1 ?B2)
-  (and
-    (instance ?A1 AutonomousAgent)
-    (instance ?A2 AutonomousAgent)
-    (not (equal ?A1 ?A2))
-    (operationalBudget ?A1 ?B1)
-    (operationalBudget ?A2 ?B2)
-    (not (equal ?B1 ?B2))))
-
 ;; ============================================================
 ;; operationalBudgetInPeriod (TernaryPredicate)
 ;; ============================================================
@@ -302,32 +293,12 @@ cost.")
     (measure ?TOTAL ?AMOUNT))
   (greaterThanOrEqualTo ?AMOUNT 0))
 
-;; rule: aggregateCyberCost can equal the sum of a single exploitCost and a
+;; aggregateCyberCost can equal the sum of a single exploitCost and a
 ;; single patchCost -- the simplest case of the general "sum of per-action
-;; costs" claim in the documentation
-
-(exists (?AGENT ?T ?VUL1 ?VUL2 ?C1 ?C2 ?AMOUNT1 ?AMOUNT2 ?TOTAL)
-  (and
-    (instance ?AGENT AutonomousAgent)
-    (instance ?T TimeInterval)
-    (instance ?VUL1 Vulnerability)
-    (instance ?VUL2 Vulnerability)
-    (holdsDuring ?T (exploitCost ?VUL1 ?AGENT ?C1))
-    (holdsDuring ?T (patchCost ?VUL2 ?AGENT ?C2))
-    (measure ?C1 ?AMOUNT1)
-    (measure ?C2 ?AMOUNT2)
-    (aggregateCyberCost ?AGENT ?T ?TOTAL)
-    (measure ?TOTAL (AdditionFn ?AMOUNT1 ?AMOUNT2))))
-
-(exists (?AGENT ?T1 ?T2 ?TOT1 ?TOT2)
-  (and
-    (instance ?AGENT AutonomousAgent)
-    (instance ?T1 TimeInterval)
-    (instance ?T2 TimeInterval)
-    (not (equal ?T1 ?T2))
-    (aggregateCyberCost ?AGENT ?T1 ?TOT1)
-    (aggregateCyberCost ?AGENT ?T2 ?TOT2)
-    (not (equal ?TOT1 ?TOT2))))
+;; costs" claim in the documentation. Non-triviality witnesses for this and
+;; the interval-relative claim live at
+;; proof-scenarios/aggregatecybercost_exploit_plus_patch_sum.tq and
+;; proof-scenarios/aggregatecybercost_interval_relative.tq, not as KB axioms.
 
 ;; ============================================================
 ;; ViolatedKnapsack (RelationalAttribute)
@@ -353,38 +324,6 @@ same agent may satisfy in one interval and violate in another.")
     (greaterThan ?TOTAL_AMOUNT ?BUDGET_AMOUNT))
   (holdsDuring ?T
     (attribute ?AGENT ViolatedKnapsack)))
-
-(exists (?A1 ?A2 ?T ?B1 ?B2 ?TOT1 ?TOT2 ?BA1 ?BA2 ?TA1 ?TA2)
-  (and
-    (instance ?A1 AutonomousAgent)
-    (instance ?A2 AutonomousAgent)
-    (not (equal ?A1 ?A2))
-    (instance ?T TimeInterval)
-    (operationalBudget ?A1 ?B1)
-    (operationalBudget ?A2 ?B2)
-    (aggregateCyberCost ?A1 ?T ?TOT1)
-    (aggregateCyberCost ?A2 ?T ?TOT2)
-    (measure ?B1 ?BA1)
-    (measure ?B2 ?BA2)
-    (measure ?TOT1 ?TA1)
-    (measure ?TOT2 ?TA2)
-    (greaterThan ?TA1 ?BA1)
-    (not (greaterThan ?TA2 ?BA2))))
-
-(exists (?AGENT ?T1 ?T2 ?B ?TOT1 ?TOT2 ?BA ?TA1 ?TA2)
-  (and
-    (instance ?AGENT AutonomousAgent)
-    (instance ?T1 TimeInterval)
-    (instance ?T2 TimeInterval)
-    (not (equal ?T1 ?T2))
-    (operationalBudget ?AGENT ?B)
-    (aggregateCyberCost ?AGENT ?T1 ?TOT1)
-    (aggregateCyberCost ?AGENT ?T2 ?TOT2)
-    (measure ?B ?BA)
-    (measure ?TOT1 ?TA1)
-    (measure ?TOT2 ?TA2)
-    (not (greaterThan ?TA1 ?BA))
-    (greaterThan ?TA2 ?BA)))
 
 ;; ============================================================
 ;; operationalTempo (TernaryPredicate)
@@ -504,17 +443,6 @@ from arXiv:2403.10789.")
   (exists (?BUDGET)
     (operationalBudget ?AGENT ?BUDGET)))
 
-(exists (?AK ?A1 ?A2 ?B1 ?B2)
-  (and
-    (instance ?AK AdversarialKnapsack)
-    (instance ?A1 AutonomousAgent)
-    (instance ?A2 AutonomousAgent)
-    (not (equal ?A1 ?A2))
-    (contestParticipant ?AK ?A1)
-    (contestParticipant ?AK ?A2)
-    (operationalBudget ?A1 ?B1)
-    (operationalBudget ?A2 ?B2)
-    (not (equal ?B1 ?B2))))
 ;; ============================================================
 ;; exploitCost (TernaryPredicate)
 ;; ============================================================
@@ -558,16 +486,6 @@ there is at most one exploit cost.")
     (vulnerableSystem ?VUL ?SYS ?AGENT))
   (exists (?COST)
     (exploitCost ?VUL ?AGENT ?COST)))
-
-(exists (?VUL ?A1 ?A2 ?C1 ?C2)
-  (and
-    (instance ?VUL Vulnerability)
-    (instance ?A1 AutonomousAgent)
-    (instance ?A2 AutonomousAgent)
-    (not (equal ?A1 ?A2))
-    (exploitCost ?VUL ?A1 ?C1)
-    (exploitCost ?VUL ?A2 ?C2)
-    (not (equal ?C1 ?C2))))
 
 ;; ============================================================
 ;; KnownExploitAvailable (RelationalAttribute)
@@ -808,26 +726,11 @@ expertise costs. One of five cost components summed into &%exploitCost.")
       (measure ?TOTAL2 ?AMT2)
       (lessThanOrEqualTo ?AMT1 ?AMT2))))
 
-;; rule: exploitCost is capacity-relative -- the identical cost can be
+;; exploitCost is capacity-relative -- the identical cost can be
 ;; affordable for one agent and unaffordable for another depending on
 ;; operationalBudget, independent of exploitCost's own contribution to
-;; aggregateCyberCost/ViolatedKnapsack above
-
-(exists (?VUL ?A1 ?A2 ?B1 ?B2 ?COST)
-  (and
-    (instance ?VUL Vulnerability)
-    (instance ?A1 AutonomousAgent)
-    (instance ?A2 AutonomousAgent)
-    (not (equal ?A1 ?A2))
-    (exploitCost ?VUL ?A1 ?COST)
-    (exploitCost ?VUL ?A2 ?COST)
-    (operationalBudget ?A1 ?B1)
-    (operationalBudget ?A2 ?B2)
-    (measure ?COST ?AMT)
-    (measure ?B1 ?AMT1)
-    (measure ?B2 ?AMT2)
-    (lessThanOrEqualTo ?AMT ?AMT1)
-    (greaterThan ?AMT ?AMT2)))
+;; aggregateCyberCost/ViolatedKnapsack above. Non-triviality witness lives
+;; at proof-scenarios/exploitcost_capacity_relative.tq, not as a KB axiom.
 
 ;; ============================================================
 ;; patchCost (TernaryPredicate)
@@ -936,16 +839,6 @@ via &%successorAttribute, from least to most mature.")
     (patchCost ?VUL ?DEFENDER ?COST)
     (knows ?DEFENDER (attribute ?SYS ?VUL)))
   (knows ?DEFENDER (patchCost ?VUL ?DEFENDER ?COST)))
-
-(exists (?VUL ?A1 ?A2 ?C1 ?C2)
-  (and
-    (instance ?VUL Vulnerability)
-    (instance ?A1 AutonomousAgent)
-    (instance ?A2 AutonomousAgent)
-    (not (equal ?A1 ?A2))
-    (patchCost ?VUL ?A1 ?C1)
-    (patchCost ?VUL ?A2 ?C2)
-    (not (equal ?C1 ?C2))))
 
 ;; ============================================================
 ;; patchDevelopmentCost (TernaryPredicate)


### PR DESCRIPTION
AdversarialKnapsack, ViolatedKnapsack, operationalBudget, aggregateCyberCost, exploitCost, and patchCost each carried a bare, unconditional existential asserting a satisfying instance as permanent KB content. Each is now a one-time proof scenario under development/proof-scenarios/ instead, per the existing hard constraint against bare top-level (exists ...) content. Also excludes development/proof-scenarios/ and development/dev-reports/ from the committed corpus (local Vampire transcripts and diagnostics reports, generated during authoring).