### PR TITLE
Update Economy.kif

### DIFF
--- a/domainEnglishFormat.kif
+++ b/domainEnglishFormat.kif
@@ -21964,12 +21964,6 @@ denotes westerly declination. zero value means at the agonic line.")
 ;; (termFormat JapaneseLanguage EmployeeLeasingServices "従業員リースサービス")
 ;; (termFormat GermanLanguage EmployeeLeasingServices "Leasing")
 
-(termFormat EnglishLanguage Employment "employment")
-(termFormat ChineseTraditionalLanguage Employment "僱用")
-(termFormat ChineseLanguage Employment "雇用")
-;; (termFormat JapaneseLanguage Employment "雇用")
-;; (termFormat GermanLanguage Employment "Beschäftigung")
-
 (termFormat EnglishLanguage EmploymentFiring "employment firing")
 (termFormat ChineseTraditionalLanguage EmploymentFiring "就業解僱")
 (termFormat ChineseLanguage EmploymentFiring "就业解雇")


### PR DESCRIPTION
Changed OpiumFarming to match the 
Removed Employment, as this attribute is already covered with other terms, and "Employment" was unreachable to entity, leading me to believe that it was changed, but never updated in domainEnglishFormat.kif.